### PR TITLE
callUpdate() on CouchDbConnector to call document update handlers

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
@@ -1,5 +1,6 @@
 package org.ektorp;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
@@ -343,5 +344,13 @@ public interface CouchDbConnector {
 	 * @return a running changes feed that buffers incoming changes in a unbounded queue (will grow until OutOfMemoryException if not polled).
 	 */
 	ChangesFeed changesFeed(ChangesCommand cmd);
+
+	/**
+	 * Calls a document update handler
+	 * 
+	 * @return
+	 */
+	String callUpdate(String designDoc, String function, String docId)
+			throws IOException;
 
 }


### PR DESCRIPTION
Useful for emulating db integer sequences, like so

put this in _design/Foo

"updates": {
       "auto_incr": "function(doc,req) { if(doc == null) { return [{_id: req.id, next: 2 },'1'] } if(!doc.next) { doc.next = 2; } else { doc.next += 1; } return[doc,doc.next-1+'']}"
   }

public String nextOrderNumber() {
        String response;
        try {
            response = db.callUpdate(getStdDesignDocumentId(), "auto_incr",
                    "order_no");
        } catch (IOException e) {
            logger.error(e.getMessage(), e);
            return null;
        }
        return response;
    }
