### PR TITLE
Fixed nullpointer exception in ChangesCommand.Builder.merge

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/changes/ChangesCommand.java
+++ b/org.ektorp/src/main/java/org/ektorp/changes/ChangesCommand.java
@@ -162,7 +162,9 @@ public class ChangesCommand {
 			filter = other.filter;
 			includeDocs = other.includeDocs;
 			since = other.since;
-			extraQueryParams = new LinkedHashMap<String, String>(other.extraQueryParams);
+			if (other.extraQueryParams != null) {
+			    extraQueryParams = new LinkedHashMap<String, String>(other.extraQueryParams);
+			}
 			return this;
 		}
 		


### PR DESCRIPTION
  [exec] Caused by: java.lang.NullPointerException
    [exec]     at java.util.HashMap.<init>(HashMap.java:223)
    [exec]     at java.util.LinkedHashMap.<init>(LinkedHashMap.java:195)
    [exec]     at org.ektorp.changes.ChangesCommand$Builder.merge(ChangesCommand.java:165)
    [exec]     at org.ektorp.impl.StdCouchDbConnector.changesFeed(StdCouchDbConnector.java:594)
