### PR TITLE
"ok":true in bulk update response causes problems

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/BulkOperationResponseHandler.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/BulkOperationResponseHandler.java
@@ -1,13 +1,18 @@
 package org.ektorp.impl;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 
-import org.codehaus.jackson.*;
-import org.codehaus.jackson.map.*;
-import org.ektorp.*;
-import org.ektorp.http.*;
-import org.ektorp.util.*;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.ektorp.DocumentOperationResult;
+import org.ektorp.http.HttpResponse;
+import org.ektorp.http.StdResponseHandler;
+import org.ektorp.util.Documents;
 /**
  * 
  * @author henrik lundgren
@@ -37,6 +42,10 @@ public class BulkOperationResponseHandler extends StdResponseHandler<List<Docume
 			switch (jp.getCurrentToken()) {
 				case START_OBJECT:
 				jp.nextToken();
+				if ("ok".equals(jp.getCurrentName())) {
+				    jp.nextToken();
+				    jp.nextToken();
+				}
 				jp.nextToken();
 				String id = jp.getText();
 				jp.nextToken();

--- a/org.ektorp/src/test/java/org/ektorp/impl/BulkOperationResponseHandlerTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/BulkOperationResponseHandlerTest.java
@@ -1,12 +1,13 @@
 package org.ektorp.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 
-import org.codehaus.jackson.map.*;
-import org.ektorp.*;
-import org.junit.*;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.ektorp.DocumentOperationResult;
+import org.junit.Test;
 
 public class BulkOperationResponseHandlerTest {
 
@@ -21,7 +22,9 @@ public class BulkOperationResponseHandlerTest {
 		assertEquals("conflict", errors.get(0).getError());
 		assertEquals("Document update conflict.", errors.get(0).getReason());
 		
+        assertEquals("1", objects.get(1).getId());
 		assertEquals("new_rev1", objects.get(1).getRevision());
+        assertEquals("2", objects.get(2).getId());
 		assertEquals("new_rev2", objects.get(2).getRevision());
 	}
 	

--- a/org.ektorp/src/test/resources/org/ektorp/impl/bulk_response.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/bulk_response.json
@@ -1,5 +1,5 @@
 [
     {"id":"0","error":"conflict","reason":"Document update conflict."},
     {"id":"1","rev":"new_rev1"},
-    {"id":"2","rev":"new_rev2"}
+    {"ok":true,"id":"2","rev":"new_rev2"}
 ]


### PR DESCRIPTION
Bulk update response when all_or_nothing is true will return {"ok":true, ...} in the response. 

The original code would overwrite "_id" with true as it used the first field it found. That has unfortunate consequences. :)

Fixed BulkOperationResponseHandler to cater for this, and test has been improved.
