### PR TITLE
add support for shutting down the ConnectionManager

### DIFF
--- a/org.ektorp.android/src/main/java/org/ektorp/android/http/AndroidHttpClient.java
+++ b/org.ektorp.android/src/main/java/org/ektorp/android/http/AndroidHttpClient.java
@@ -152,6 +152,10 @@ public class AndroidHttpClient implements HttpClient {
 		return executeRequest(request, false);
 	}
 
+        public void shutdown() {
+                client.getConnectionManager().shutdown();
+        }
+
 	public static class Builder {
 		String host = "localhost";
 		int port = 5984;

--- a/org.ektorp/src/main/java/org/ektorp/http/HttpClient.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/HttpClient.java
@@ -26,4 +26,6 @@ public interface HttpClient {
 	
 	HttpResponse postUncached(String uri, String content);
 
+	void shutdown();
+
 }

--- a/org.ektorp/src/main/java/org/ektorp/http/StdHttpClient.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/StdHttpClient.java
@@ -151,6 +151,10 @@ public class StdHttpClient implements HttpClient {
 		return executeRequest(request, false);
 	}
 
+	public void shutdown() {
+		client.getConnectionManager().shutdown();
+	}
+
 	public static class Builder {
 		String host = "localhost";
 		int port = 5984;


### PR DESCRIPTION
While testing on Android I observed that as I would continue to create new instances of HttpClient I would end up leaking RefQueueWorker threads.  I believe it results from our use ThreadSafeClientConnManager.  Currently the HttpClient abstraction does not offer a way for an application to properly clean this up.

This patch adds a shutdown() method the HttpClient, which implementations can use to cleanup anything they need to.  In the case of Apache HttpClient we need to call shutdown() on the ConnectionManager to clean up this thread.
