### PR TITLE
Add source jar generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,17 @@
 					<localCheckout>true</localCheckout>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>


### PR DESCRIPTION
While trying to compile Ektorp on my side I saw that there was no source jar generated, which is pretty handy to have inside Eclipse. So I just went ahead and modified the pom.xml to enable it with the maven-source-plugin. Enjoy!
