### PR TITLE
added support for the update_seq parameter when querying views

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
@@ -50,6 +50,7 @@ public class ViewQuery {
 	private boolean includeDocs = false;
 	private boolean inclusiveEnd = true;
 	private boolean ignoreNotFound = false;
+	private boolean updateSeq = false;
 
 	private String cachedQuery;
 	private String listName;
@@ -121,6 +122,10 @@ public class ViewQuery {
 
     public boolean isInclusiveEnd() {
         return inclusiveEnd;
+    }
+
+    public boolean isUpdateSeq() {
+        return updateSeq;
     }
 
     public ViewQuery dbPath(String s) {
@@ -503,6 +508,17 @@ public class ViewQuery {
 		return this;
 	}
 
+	/**
+	 * The update_seq option adds a field to the result indicating the update_seq the view reflects.  It defaults to false.
+	 * @param b the updateSeq flag
+	 * @return the view query for chained calls
+	 */
+	public ViewQuery updateSeq(boolean b) {
+		reset();
+		updateSeq = b;
+		return this;
+	}
+
 	public ViewQuery queryParam(String name, String value) {
 		queryParams.put(name, value);
 		return this;
@@ -606,6 +622,10 @@ public class ViewQuery {
 			appendQueryParams(query);
 		}
 
+		if(updateSeq) {
+			query.param("update_seq", "true");
+		}
+
 		cachedQuery = query.toString();
 		return cachedQuery;
 	}
@@ -673,6 +693,7 @@ public class ViewQuery {
 		result = prime * result + (ignoreNotFound ? 1231 : 1237);
 		result = prime * result + (includeDocs ? 1231 : 1237);
 		result = prime * result + (inclusiveEnd ? 1231 : 1237);
+		result = prime * result + (updateSeq ? 1231 : 1237);
 		result = prime * result + ((key == null) ? 0 : key.hashCode());
 		result = prime * result + limit;
 		result = prime * result
@@ -735,6 +756,8 @@ public class ViewQuery {
 		if (includeDocs != other.includeDocs)
 			return false;
 		if (inclusiveEnd != other.inclusiveEnd)
+			return false;
+		if (updateSeq != other.updateSeq)
 			return false;
 		if (key == null) {
 			if (other.key != null)

--- a/org.ektorp/src/main/java/org/ektorp/ViewResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewResult.java
@@ -16,9 +16,11 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 
 	private static final String OFFSET_FIELD_NAME = "offset";
 	private static final String TOTAL_ROWS_FIELD_NAME = "total_rows";
+	private static final String UPDATE_SEQ = "update_seq";
 	private static final long serialVersionUID = 4750290767933801714L;
 	private int totalRows = -1;
 	private int offset = -1;
+	private String updateSeq;
 	private List<Row> rows;
     private final boolean ignoreNotFound;
 	
@@ -31,6 +33,12 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 		}
 		if (resultNode.get(OFFSET_FIELD_NAME) != null) {
 			offset = resultNode.get(OFFSET_FIELD_NAME).getIntValue();
+		}
+		if (resultNode.get(UPDATE_SEQ) != null) {
+			updateSeq = resultNode.get(UPDATE_SEQ).getTextValue();
+                        if(updateSeq == null) {
+                                updateSeq = Long.toString(resultNode.get(UPDATE_SEQ).getIntValue());
+                        }
 		}
 		JsonNode rowsNode = resultNode.get("rows");
 		rows = new ArrayList<ViewResult.Row>(rowsNode.size());
@@ -72,7 +80,37 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 	void setTotalRows(int i) {
 		this.totalRows = i;
 	}
-	
+
+	/**
+	 * @return -1L if result did not contain an update_seq field
+	 */
+	public long getUpdateSeq() {
+		if(updateSeq != null) {
+			return Long.parseLong(updateSeq);
+		}
+		return -1L;
+	}
+
+	/**
+	 * @return false if db is an Cloudant instance.
+	 */
+	public boolean isUpdateSeqNumeric() {
+		return updateSeq != null && updateSeq.matches("^\\d*$");
+	}
+
+	/**
+	 *
+	 * @return null if result did not contain an update_seq field
+	 */
+	public String getUpdateSeqAsString() {
+		return updateSeq;
+	}
+
+	@JsonProperty(UPDATE_SEQ)
+	public void setUpdateSeq(String updateSeq) {
+		this.updateSeq = updateSeq;
+	}
+
 	public Iterator<ViewResult.Row> iterator() {
 		return rows.iterator();
 	}

--- a/org.ektorp/src/test/java/org/ektorp/ViewQueryTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/ViewQueryTest.java
@@ -211,6 +211,14 @@ public class ViewQueryTest {
 			.buildQuery();
 		assertTrue(contains(url, "?include_docs=true"));
 	}
+
+        @Test
+        public void update_seq_parameter_added() {
+                String url = query
+                        .updateSeq(true)
+                        .buildQuery();
+                assertTrue(contains(url, "?update_seq=true"));
+        }
 	
 	@Test
 	public void stale_ok_parameter_added() {

--- a/org.ektorp/src/test/java/org/ektorp/ViewResultTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/ViewResultTest.java
@@ -82,6 +82,23 @@ public class ViewResultTest {
 	public void view_result_with_error_row() throws Exception {
 		readResult("impl/view_result_with_error.json");
 	}
+
+        @Test
+        public void int_update_seq_view_result() throws Exception {
+
+                ViewResult result = readResult("impl/view_result_with_int_update_seq.json");
+		assertTrue(result.isUpdateSeqNumeric());
+                assertEquals(1234, result.getUpdateSeq());
+		assertEquals("1234", result.getUpdateSeqAsString());
+	}
+
+        @Test
+        public void string_update_seq_view_result() throws Exception {
+
+                ViewResult result = readResult("impl/view_result_with_string_update_seq.json");
+                assertFalse(result.isUpdateSeqNumeric());
+                assertEquals("1234-abc", result.getUpdateSeqAsString());
+        }
 	
 	private ViewResult readResult(String path) throws Exception {
 		return new ViewResult(om.readTree(getClass().getResourceAsStream(path)), false);

--- a/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_int_update_seq.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_int_update_seq.json
@@ -1,0 +1,4 @@
+{"total_rows":2,"offset":1,"update_seq": 1234,"rows":[
+{"id":"doc_id1","key":"key_value","value":"doc_value1"},
+{"id":"doc_id2","key":"key_value","value":"doc_value2"}
+]}

--- a/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_string_update_seq.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_string_update_seq.json
@@ -1,0 +1,4 @@
+{"total_rows":2,"offset":1,"update_seq": "1234-abc","rows":[
+{"id":"doc_id1","key":"key_value","value":"doc_value1"},
+{"id":"doc_id2","key":"key_value","value":"doc_value2"}
+]}


### PR DESCRIPTION
This patch adds support for the update_seq=true parameter when querying views.  I've tried to support both int and String values (since presumably Cloudant could support this parameter in the future).  I've also added some basic tests around the handling of this parameter in the query and result.
