### PR TITLE
MIME multipart updates

### DIFF
--- a/doc/src/docbkx/reference_doc.xml
+++ b/doc/src/docbkx/reference_doc.xml
@@ -1095,6 +1095,24 @@ sofa.getRevision();</programlisting>
 
       <para>Note that calling update with an object that has an empty id field
       will create a new document in the database.</para>
+
+        <section>
+            <title>Updating from a Stream</title>
+            <para>
+                Documents can be updated from an InputStream. The InputStream must contain a JSON document. Using
+                an InputStream allows you to update a document from a JSON document without having to parse it, which
+                can be more efficient for large documents.
+            </para>
+
+            <programlisting language="java">
+                File file = someMethodToGetFile();
+                InputStream jsonInputStream = new FileInputStream(file);
+                db.update("document_id",
+                          jsonInputStream,
+                          file.length(),
+                          null);
+            </programlisting>
+        </section>
     </section>
 
     <section>
@@ -1617,18 +1635,6 @@ db.createAttachment("existing_document_id", "document_revision", a);</programlis
                   CouchDB Multiple Attachments API
               </link>.
           </para>
-
-          <para>To update a document as a MIME multipart/related without attachments, use
-              the updateMultipart overload which does not have a boundary parameter. In this
-              case the InputStream is just the JSON document.
-          </para>
-
-          <programlisting language="java">
-              db.updateMultipart("document_id",
-                                 mimeInputStream,
-                                 file.length(),
-                                 new Options());
-          </programlisting>
 
       </section>
   </chapter>

--- a/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
@@ -576,14 +576,12 @@ public interface CouchDbConnector {
 	void updateMultipart(String id, InputStream stream, String boundary, long length, Options options);
 
 	/**
-	 * Sends a document to the Couch server as a MIME multipart/related message without
-	 * a boundary.
+	 * Sends a document to the Couch server as a JSON stream
 	 * @param id the document ID
-	 * @param stream an InputStream of the multipart message containing
-	 *                  the document and any attachments
-	 * @param length the length of the MIME multipart message stream
+	 * @param document an InputStream of the JSON document
+	 * @param length the length of the JSON document
 	 * @param options options to pass to the Couch request
 	 */
-	void updateMultipart(String id, InputStream stream, long length, Options options);
+	void update(String id, InputStream document, long length, Options options);
 
 }

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
@@ -821,20 +821,23 @@ public class StdCouchDbConnector implements CouchDbConnector {
 	@Override
 	public void updateMultipart(String id, InputStream stream, String boundary, long length, Options options) {
 		assertDocIdHasValue(id);
+		Assert.hasText(boundary);
 		URI uri = dbURI.append(id);
 		applyOptions(options, uri);
 
-		String contentType = boundary != null ?
-				String.format("multipart/related; boundary=\"%s\"", boundary) :
-				"multipart/related";
+		String contentType = String.format("multipart/related; boundary=\"%s\"", boundary);
 
 		restTemplate.put(uri.toString(), stream, contentType, length);
 	}
 
 	@Override
-	public void updateMultipart(String id, InputStream stream, long length, Options options)
+	public void update(String id, InputStream document, long length, Options options)
 	{
-		updateMultipart(id, stream, null, length, options);
+		assertDocIdHasValue(id);
+		URI uri = dbURI.append(id);
+		applyOptions(options, uri);
+
+		restTemplate.put(uri.toString(), document, "application/json", length);
 	}
 
 }

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
@@ -638,7 +638,7 @@ public class StdCouchDbConnectorTest {
 	@Test
 	public void updateMultipart_should_perform_put_operation_with_path_set_to_db_followed_by_id() {
 		String id = UUID.randomUUID().toString();
-		dbCon.updateMultipart(id, null, null, 0, null);
+		dbCon.updateMultipart(id, null, "abc", 0, null);
 
 		String expectedPath = "/test_db/" + id;
 		verify(httpClient).put(eq(expectedPath), any(InputStream.class), anyString(), anyLong());
@@ -650,7 +650,7 @@ public class StdCouchDbConnectorTest {
 		String paramName = "some_param";
 		String paramValue = "false";
 		Options options = new Options().param(paramName, paramValue);
-		dbCon.updateMultipart(id, null, null, 0, options);
+		dbCon.updateMultipart(id, null, "abc", 0, options);
 
 		String expectedPath = "/test_db/" + id + "?some_param=false";
 		verify(httpClient).put(eq(expectedPath), any(InputStream.class), anyString(), anyLong());
@@ -659,7 +659,7 @@ public class StdCouchDbConnectorTest {
 	@Test
 	public void updateMultipart_should_perform_put_operation_with_the_given_InputStream() {
 		InputStream stream = mock(InputStream.class);
-		dbCon.updateMultipart("a", stream, null, 0, null);
+		dbCon.updateMultipart("a", stream, "abc", 0, null);
 
 		verify(httpClient).put(anyString(), eq(stream), anyString(), anyLong());
 	}
@@ -673,28 +673,33 @@ public class StdCouchDbConnectorTest {
 		verify(httpClient).put(anyString(), any(InputStream.class), eq(expectedContentType), anyLong());
 	}
 
-	@Test
-	public void updateMultipart_should_perform_put_operation_with_content_type_set_to_multipart_related_with_no_boundary_if_it_is_null() {
+	@Test(expected = IllegalArgumentException.class)
+	public void updateMultipart_should_throw_if_boundary_is_null() {
 		dbCon.updateMultipart("a", null, null, 0, null);
-
-		String expectedContentType = "multipart/related";
-		verify(httpClient).put(anyString(), any(InputStream.class), eq(expectedContentType), anyLong());
 	}
 
 	@Test
 	public void updateMultipart_should_perform_put_operation_with_content_type_set_to_length() {
 		long length = 1000l;
-		dbCon.updateMultipart("a", null, null, length, null);
+		dbCon.updateMultipart("a", null, "abc", length, null);
 
 		verify(httpClient).put(anyString(), any(InputStream.class), anyString(), eq(length));
 	}
 
 	@Test
-	public void updateMultipart_without_boundary_should_perform_put_operation_with_content_type_set_to_multipart_related_with_no_boundary() {
-		dbCon.updateMultipart("a", null, 0, null);
+	public void update_with_stream_should_perform_put_operation_with_content_type_set_to_application_json() {
+		String documentId = UUID.randomUUID().toString();
+		InputStream inputStream = mock(InputStream.class);
+		long documentLength = 999l;
+		String paramName = "some_param";
+		String paramValue = "false";
+		Options options = new Options().param(paramName, paramValue);
 
-		String expectedContentType = "multipart/related";
-		verify(httpClient).put(anyString(), any(InputStream.class), eq(expectedContentType), anyLong());
+		dbCon.update(documentId, inputStream, documentLength, options);
+
+		String expectedPath = "/test_db/" + documentId + "?some_param=false";
+		String expectedContentType = "application/json";
+		verify(httpClient).put(expectedPath, inputStream, expectedContentType, documentLength);
 	}
 
     @SuppressWarnings("serial")


### PR DESCRIPTION
I made a change to support Couch's MIME multipart/related PUT operation. This allows for pushing a document along with its attachments relatively efficiently.

More information on this Couch API is available:
http://wiki.apache.org/couchdb/HTTP_Document_API#Multiple_Attachments
