### PR TITLE
Fix bug in Options with includeRevisions.

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/Options.java
+++ b/org.ektorp/src/main/java/org/ektorp/Options.java
@@ -23,7 +23,7 @@ public class Options {
 	 * @return
 	 */
 	public Options includeRevisions() {
-		options.put("revisions", "true");
+		options.put("revs", "true");
 		return this;
 	}
 	/**


### PR DESCRIPTION
Parameter "revisions" is not a valid parameter. The real parameter is "revs" to describes all documents revisions.
