### PR TITLE
Ignore unknown properties

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
@@ -1,5 +1,6 @@
 package org.ektorp.impl;
 
+import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig.Feature;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
@@ -43,6 +44,7 @@ public class StdObjectMapperFactory implements ObjectMapperFactory {
 
 	private void applyDefaultConfiguration(ObjectMapper om) {
 		om.configure(Feature.WRITE_DATES_AS_TIMESTAMPS, writeDatesAsTimestamps);
+		om.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		om.getSerializationConfig().setSerializationInclusion(
 				Inclusion.NON_NULL);
 	}


### PR DESCRIPTION
CouchDB releases frequently add new properties. Ektorp should not fail
when encountering these.
