### PR TITLE
Added test case for view result which includes a deleted document.

### DIFF
--- a/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
@@ -361,7 +361,7 @@ public class StdCouchDbConnectorTest {
                 .designDocId("_design/testdoc")
                 .viewName("test_view")
                 .includeDocs(true)                
-                .keys(Arrays.asList("doc_id1", "doc_id2", "doc_id3", "doc_id4"));
+                .keys(Arrays.asList("doc_id0", "doc_id1", "doc_id2", "doc_id3", "doc_id4", "doc_id5", "doc_id6"));
         query.setIgnoreNotFound(true);
 
         when(httpClient.postUncached(anyString(), anyString())).thenReturn(
@@ -369,10 +369,11 @@ public class StdCouchDbConnectorTest {
 
         List<TestDoc> result = dbCon.queryView(query, TestDoc.class);
 
-        assertEquals(2, result.size());
+        assertEquals(3, result.size());
         assertEquals(TestDoc.class, result.get(0).getClass());
         assertEquals("doc_id1", result.get(0).getId());
         assertEquals("doc_id3", result.get(1).getId());
+        assertEquals("doc_id6", result.get(2).getId());
         verify(httpClient).postUncached(query.buildQuery(), query.getKeysAsJson());
     }
 

--- a/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_ignored_docs.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_ignored_docs.json
@@ -1,6 +1,9 @@
 {"total_rows":4,"rows":[
-{"id":"doc_id1","key":"key_value","value":null,"doc":{"_id":"doc_id1", "_rev":"rev1", "name":"foo", "age":12}},
+{"key":"doc_id0","error":"not_found"},
+{"id":"doc_id1","key":"doc_id1","value":null,"doc":{"_id":"doc_id1", "_rev":"rev1", "name":"foo", "age":12}},
 {"key":"doc_id2","error":"not_found"},
-{"id":"doc_id3","key":"key_value","value":null,"doc":{"_id":"doc_id3", "_rev":"rev3", "name":"bar", "age":99}},
-{"key":"doc_id4","error":"not_found"}
+{"id":"doc_id3","key":"doc_id3","value":null,"doc":{"_id":"doc_id3", "_rev":"rev3", "name":"bar", "age":99}},
+{"key":"doc_id4","error":"not_found"},
+{"id":"doc_id5","key":"doc_id5","value":{"rev":"rev4","deleted":true},"doc":null},
+{"id":"doc_id6","key":"doc_id6","value":null,"doc":{"_id":"doc_id6", "_rev":"rev1", "name":"baz", "age":76}}
 ]}


### PR DESCRIPTION
In the StdCouchDbConnectorTest.queries_with_ignore_not_found() test 'doc_id6' is never returned because of the deleted 'doc_id5'. I have not yet been able to fix this issue as I'm not that familiar with the parsing code.
