### PR TITLE
Added possiblity to query couchDb for the current revision of a document...

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
@@ -234,6 +234,15 @@ public interface CouchDbConnector {
     List<Revision> getRevisions(String id);
 
     /**
+     * Obtain the current revision of a document using a lightweight request.
+     * @param id
+     * @return
+     * @throws DocumentNotFoundException
+     *             if the document was not found.
+     */
+    String getCurrentRevision(String id);
+    
+    /**
      * Reads an attachment from the database.
      * 
      * Please note that the stream has to be closed after usage, otherwise http connection leaks will occur and the

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
@@ -321,6 +321,18 @@ public class StdCouchDbConnector implements CouchDbConnector {
     }
 
     @Override
+    public String getCurrentRevision(String id) {
+    	assertDocIdHasValue(id);
+    	return restTemplate.head(dbURI.append(id).toString(), new StdResponseHandler<String>(){
+    		@Override
+    		public String success(HttpResponse hr) throws Exception {
+    			return hr.getETag();
+    		}
+    	});
+    }
+    
+    
+    @Override
     public InputStream getAsStream(String id) {
         assertDocIdHasValue(id);
         return getAsStream(id, EMPTY_OPTIONS);

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
@@ -1,10 +1,7 @@
 package org.ektorp.impl;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -261,6 +258,20 @@ public class StdCouchDbConnectorTest {
         assertEquals(8, l.size());
         assertEquals(new Revision("8-8395fd3a7a2dd04022cc1330a4d20e66", "available"), l.get(0));
     }
+    
+    @Test
+	public void return_current_revision() {
+		final String revision = UUID.randomUUID().toString();
+		when(httpClient.head("/test_db/some_doc_id")).thenReturn(
+				new HttpResponseStub(200, "") {
+					@Override
+					public String getETag() {
+						return revision;
+					}
+				});
+		String currentRevision = dbCon.getCurrentRevision("some_doc_id");
+		assertEquals(revision, currentRevision);
+	}
 
     @Test
     public void return_null_revisions_when_doc_is_missing() {


### PR DESCRIPTION
... using the HEAD endpoint.
