### PR TITLE
Attempting to create a document with empty ID can create a database

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
@@ -116,7 +116,7 @@ public class StdCouchDbConnector implements CouchDbConnector {
         String json = jsonSerializer.toJson(o);
         String id = Documents.getId(o);
         DocumentOperationResult result;
-        if (id != null && !id.length() == 0) {
+        if (id != null && id.length() != 0) {
             result = restTemplate.put(URIWithDocId(id), json, revisionHandler);
         } else {
             result = restTemplate.post(dbURI.toString(), json, revisionHandler);


### PR DESCRIPTION
The following code will create the database "foo" if it doesn't already exist. This patch fixes that issue.

HttpClient httpClient = new StdHttpClient.Builder().build();
CouchDbInstance dbInstance = new StdCouchDbInstance(httpClient);
CouchDbConnector db = dbInstance.createConnector("foo", false);

Map<String, Object> document = new HashMap<String, Object>() {{
           put("_id", "");
           put("field", 12345);
        }};

db.create(document); // Sends a PUT request to localhost:5984/foo/, which creates a new DB rather than a new document.
