### PR TITLE
Add an overload to CouchDbInstance.checkIfDbExists which takes a string

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/CouchDbInstance.java
+++ b/org.ektorp/src/main/java/org/ektorp/CouchDbInstance.java
@@ -23,6 +23,7 @@ public interface CouchDbInstance {
 	 * @return true if the database exists.
 	 */
 	boolean checkIfDbExists(DbPath db);
+	boolean checkIfDbExists(String path);
 
 	void createDatabase(DbPath path);
 	void createDatabase(String path);

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbInstance.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbInstance.java
@@ -57,6 +57,11 @@ public class StdCouchDbInstance implements CouchDbInstance {
 		Assert.notNull(path);
 		restTemplate.delete(DbPath.fromString(path).getPath());
 	}
+	
+	@Override
+	public boolean checkIfDbExists(String path) {
+	    return checkIfDbExists(DbPath.fromString(path));
+	}
 
 	@Override
 	public boolean checkIfDbExists(DbPath db) {


### PR DESCRIPTION
For convenience, added an overload to CouchDbInstance.checkIfDbExists so you can just give it the DB name as a string, rather than having to pass it a DbPath.
