### PR TITLE
Moved logging in HttpClientFactoryBean.afterPropertiesSet()

### DIFF
--- a/org.ektorp.spring/src/main/java/org/ektorp/spring/HttpClientFactoryBean.java
+++ b/org.ektorp.spring/src/main/java/org/ektorp/spring/HttpClientFactoryBean.java
@@ -171,11 +171,10 @@ public class HttpClientFactoryBean implements FactoryBean<HttpClient>, Initializ
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		LOG.info("Starting couchDb connector on {}:{}...",  new Object[]{host,port});
 		if (couchDBProperties != null) {
 			new DirectFieldAccessor(this).setPropertyValues(couchDBProperties);
 		}
-		
+		LOG.info("Starting couchDb connector on {}:{}...",  new Object[]{host,port});
 		LOG.debug("host: {}", host);
 		LOG.debug("port: {}", port);
 		LOG.debug("url: {}", url);


### PR DESCRIPTION
The info logging is done before the properties has been applied.
Properties might affect host and port. So the info logging has the ability to be incorrect.
