### PR TITLE
Fix idle connection monitoring

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/http/IdleConnectionMonitor.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/IdleConnectionMonitor.java
@@ -14,7 +14,7 @@ public class IdleConnectionMonitor {
 		private final AtomicInteger threadCount = new AtomicInteger(0);
 		
 		public Thread newThread(Runnable r) {
-			Thread t = new Thread();
+			Thread t = new Thread(r);
 			t.setDaemon(true);
 			t.setName(String.format("ektorp-idle-connection-monitor-thread-%s", threadCount.incrementAndGet()));
 			return t;


### PR DESCRIPTION
Currently idle connection monitoring does nothing, because the newThread method doesn't use the runnable it's given, so CleanupTask.run() is never called. This extraordinarily small patch fixes that.
