### PR TITLE
Include all revisions in DocumentChange

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/changes/DocumentChange.java
+++ b/org.ektorp/src/main/java/org/ektorp/changes/DocumentChange.java
@@ -1,6 +1,9 @@
 package org.ektorp.changes;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
 /**
  * Represents a document change within a database.
  * @author henrik lundgren
@@ -21,6 +24,14 @@ public interface DocumentChange {
 	 * @return the revision the document had at the time of change.
 	 */
 	String getRevision();
+
+    /**
+     *
+     * @return the collection of revisions, including conflicts
+     * @since 1.4.0
+     */
+    public List<String> getRevisions();
+
 	/**
 	 *
 	 * @return true if the changed document has been deleted.

--- a/org.ektorp/src/main/java/org/ektorp/impl/changes/StdDocumentChange.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/changes/StdDocumentChange.java
@@ -3,6 +3,11 @@ package org.ektorp.impl.changes;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.ektorp.changes.*;
 import org.ektorp.util.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  *
  * @author henrik lundgren
@@ -15,10 +20,11 @@ public class StdDocumentChange implements DocumentChange {
 	private static final String ID_FIELD_NAME = "id";
 	private static final String DOC_FIELD_NAME = "doc";
 	private static final String DELETED_FIELD_NAME = "deleted";
+    private static final String CHANGES_FIELD_NAME = "changes";
 
-	private final JsonNode node;
+    private final JsonNode node;
 
-	public StdDocumentChange(JsonNode node) {
+    public StdDocumentChange(JsonNode node) {
 		Assert.notNull(node, "node may not be null");
 		this.node = node;
 	}
@@ -54,8 +60,16 @@ public class StdDocumentChange implements DocumentChange {
 	}
 
 	public String getRevision() {
-		return nodeAsString(node.findPath(REV_FIELD_NAME));
+        return nodeAsString(node.findValue(REV_FIELD_NAME));
 	}
+
+    public List<String> getRevisions() {
+        List<String> revisions = new ArrayList<String>();
+        for (JsonNode changesNode : node.get(CHANGES_FIELD_NAME)) {
+            revisions.add(nodeAsString(changesNode.get(REV_FIELD_NAME)));
+        }
+        return Collections.unmodifiableList(revisions);
+    }
 
 	@Override
 	public String toString() {

--- a/org.ektorp/src/test/java/org/ektorp/impl/changes/StdDocumentChangeTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/changes/StdDocumentChangeTest.java
@@ -1,22 +1,20 @@
 package org.ektorp.impl.changes;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import junit.framework.Assert;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import junit.framework.Assert;
 import org.ektorp.StreamingChangesResult;
 import org.ektorp.changes.DocumentChange;
 import org.ektorp.http.HttpResponse;
 import org.ektorp.impl.ResponseOnFileStub;
 import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.hasItems;
 
 public class StdDocumentChangeTest {
 
@@ -53,9 +51,34 @@ public class StdDocumentChangeTest {
 		assertNotNull(m.getDocAsNode().findValue("_id"));
 		assertNotNull(m.getDocAsNode().findValue("_rev"));
 	}
-	
-	
-	@Test
+
+    @Test
+    public void getRevision_should_return_the_first_revision_when_there_are_multiple_changes() throws IOException
+    {
+        StdDocumentChange objectUnderTest = new StdDocumentChange(load("change_message_w_multiple_revs.json"));
+        assertThat(objectUnderTest.getId(), is("doc_id"));
+        assertThat(objectUnderTest.getRevision(), is("rev-first"));
+        assertNull(objectUnderTest.getDoc());
+        assertTrue(objectUnderTest.getDocAsNode().isMissingNode());
+        assertFalse(objectUnderTest.isDeleted());
+    }
+
+    @Test
+    public void getRevisions_should_return_a_List_of_all_the_changes() throws IOException
+    {
+        StdDocumentChange objectUnderTest = new StdDocumentChange(load("change_message_w_multiple_revs.json"));
+        assertThat(objectUnderTest.getId(), is("doc_id"));
+        assertThat(objectUnderTest.getRevision(), is("rev-first"));
+        assertThat(objectUnderTest.getRevisions(), notNullValue());
+        assertThat(objectUnderTest.getRevisions(), hasItems("rev-first", "rev-second", "rev-third"));
+        assertThat(objectUnderTest.getRevisions().size(), is(3));
+        assertNull(objectUnderTest.getDoc());
+        assertTrue(objectUnderTest.getDocAsNode().isMissingNode());
+        assertFalse(objectUnderTest.isDeleted());
+    }
+
+
+    @Test
     public void test_streaming_changes() throws IOException {
 	    HttpResponse httpResponse = ResponseOnFileStub.newInstance(200, "changes/changes_full.json");
 	    
@@ -67,7 +90,7 @@ public class StdDocumentChangeTest {
         }
         Assert.assertEquals(5, changes.getLastSeq());
     }
-	
+
 	private JsonNode load(String id) throws IOException {
 		return mapper.readTree(getClass().getResourceAsStream(id));
 	}

--- a/org.ektorp/src/test/resources/org/ektorp/impl/changes/change_message_w_multiple_revs.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/changes/change_message_w_multiple_revs.json
@@ -1,0 +1,1 @@
+{"seq":22,"id":"doc_id","changes":[{"rev":"rev-first"},{"rev":"rev-second"},{"rev":"rev-third"}]}


### PR DESCRIPTION
In CouchDB, when the changes feed query has style=all_docs, CouchDB returns all the revisions for a document, including conflicts.

In Ektorp, the DocumentChange had a method called getRevision. This method still returns the first revision when there are multiple available. In this pull request, I have added a new method, getRevisions, which returns a list of revisions, including conflicts.
