### PR TITLE
Added Javadoc documentation to the View class

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/support/View.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/View.java
@@ -15,12 +15,24 @@ public @interface View {
 	 */
 	String name();
 	/**
-	 * Map function.
+	 * Map function or path to function.
+     * <p>
+     * This value may be a string of code to use for the function.
+     * Alternatively, the string may specify a file to load for
+     * the function by starting the string with <i>classpath:</i>.
+     * The rest of the string then represents a relative path to
+     * the function.
 	 * @return
 	 */
 	String map() default "";
 	/**
-	 * Reduce function.
+	 * Reduce function or path to function.
+     * <p>
+     * This value may be a string of code to use for the function.
+     * Alternatively, the string may specify a file to load for
+     * the function by starting the string with <i>classpath:</i>.
+     * The rest of the string then represents a relative path to
+     * the function.
 	 * @return
 	 */
 	String reduce() default "";


### PR DESCRIPTION
I was not aware that you could add classpath: to View.map and View.reduce to specify a file. I was just about to write code to support this when I discovered that it was already supported. So I added some Javadoc comments to help users know that they can do this by adding classpath: to their string.
