### PR TITLE
Added a shutdown method to the IdleConnectionMonitor

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/http/IdleConnectionMonitor.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/IdleConnectionMonitor.java
@@ -1,10 +1,10 @@
 package org.ektorp.http;
 
+import org.apache.http.conn.ClientConnectionManager;
+
 import java.lang.ref.WeakReference;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-
-import org.apache.http.conn.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class IdleConnectionMonitor {
 
@@ -27,6 +27,10 @@ public class IdleConnectionMonitor {
         ScheduledFuture<?> cleanupFuture = executorService.scheduleWithFixedDelay(cleanupTask, DEFAULT_IDLE_CHECK_INTERVAL, 
                                                                                 DEFAULT_IDLE_CHECK_INTERVAL, TimeUnit.SECONDS);
         cleanupTask.setFuture(cleanupFuture);
+    }
+
+    public static void shutdown() {
+        executorService.shutdown();
     }
 	
 	private static class CleanupTask implements Runnable {


### PR DESCRIPTION
Currently the IdlConnectionMonitor leaks memory in servlet containers like Tomcat. There is currently no way to cleanly shutdown the ExecutorService. I added a public shutdown() method which will call shutdown() on the ExecutorService, thus cleaning out the threads.
