### PR TITLE
Support update_seq in view result

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/QueryResultParser.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/QueryResultParser.java
@@ -1,21 +1,20 @@
 package org.ektorp.impl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.ektorp.DbAccessException;
-import org.ektorp.ViewResultException;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ektorp.DbAccessException;
+import org.ektorp.ViewResultException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Henrik Lundgren (original implementation)
@@ -31,10 +30,12 @@ public class QueryResultParser<T> {
     private static final String INCLUDED_DOC_FIELD_NAME = "doc";
     private static final String TOTAL_ROWS_FIELD_NAME = "total_rows";
     private static final String OFFSET_FIELD_NAME = "offset";
+    private static final String UPDATE_SEQUENCE_NAME = "update_seq";
 
     private int totalRows = -1;
     private int offset = -1;
     private List<T> rows;
+    private Long updateSequence;
 
     private String firstId;
     private JsonNode firstKey;
@@ -77,6 +78,8 @@ public class QueryResultParser<T> {
             } else if (ROWS_FIELD_NAME.equals(currentName)) {
                 rows = new ArrayList<T>();
                 parseRows(jp);
+            } else if (UPDATE_SEQUENCE_NAME.equals(currentName)) {
+                updateSequence = jp.getLongValue();
             } else {
                 // Handle cloudant errors.
                 errorFields.put(jp.getCurrentName(), jp.getText());
@@ -192,6 +195,10 @@ public class QueryResultParser<T> {
 
     public void setIgnoreNotFound(boolean ignoreNotFound) {
         this.ignoreNotFound = ignoreNotFound;
+    }
+
+    public Long getUpdateSequence() {
+        return updateSequence;
     }
 
     @JsonAutoDetect(fieldVisibility = Visibility.ANY)

--- a/org.ektorp/src/test/java/org/ektorp/impl/QueryResultParserTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/QueryResultParserTest.java
@@ -1,18 +1,19 @@
 package org.ektorp.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.ektorp.DbAccessException;
 import org.ektorp.ViewResultException;
 import org.ektorp.support.CouchDbDocument;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class QueryResultParserTest {
 
@@ -69,7 +70,23 @@ public class QueryResultParserTest {
 		assertEquals("Silverchair", parser.getLastKey().textValue());
 	}
 
-	@Test( expected = ViewResultException.class )
+    @Test
+    public void test_update_sequence_should_be_parsed() throws Exception {
+        parser.parseResult(loadData("view_result_with_update_seq.json"));
+        List<TestDoc> result = parser.getRows();
+        assertEquals(2, result.size());
+        assertEquals(75, (long)parser.getUpdateSequence());
+    }
+
+    @Test
+    public void test_update_sequence_should_be_null_when_it_is_not_present() throws Exception {
+        parser.parseResult(loadData("view_result_with_included_docs.json"));
+        List<TestDoc> result = parser.getRows();
+        assertEquals(2, result.size());
+        assertNull(parser.getUpdateSequence());
+    }
+
+    @Test( expected = ViewResultException.class )
 	public void given_view_result_contains_error_then_exception_should_be_thrown() throws Exception {
 		parser.parseResult(loadData("view_result_with_error.json"));
 	}

--- a/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_update_seq.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/view_result_with_update_seq.json
@@ -1,0 +1,4 @@
+{"total_rows":2,"offset":1,"update_seq":75,"rows":[
+    {"id":"doc_id1","key":"key_value","value":{"_id":"doc_id1", "_rev":"rev1", "name":"foo", "age":12}},
+    {"id":"doc_id2","key":"key_value","value":{"_id":"doc_id2", "_rev":"rev2", "name":"bar", "age":99}}
+]}


### PR DESCRIPTION
I found that in CouchDB 1.2.0 a POST to a view returns the update_seq, even if it was not specified. So my queries from Ektorp were failing with a DbAccessException since the QueryParser did not expect that field. I updated the query parser to read the update_seq if it is present.
