### PR TITLE
Feature/expect 100

### DIFF
--- a/org.ektorp.spring/src/main/java/org/ektorp/spring/HttpClientFactoryBean.java
+++ b/org.ektorp.spring/src/main/java/org/ektorp/spring/HttpClientFactoryBean.java
@@ -191,7 +191,7 @@ public class HttpClientFactoryBean implements FactoryBean<HttpClient>, Initializ
 		LOG.debug("cleanupIdleConnections: {}", cleanupIdleConnections);
 		LOG.debug("enableSSL: {}", enableSSL);
 		LOG.debug("relaxedSSLSettings: {}", relaxedSSLSettings);
-		LOG.debug("useEpectContinue: {}", useExpectContinue);
+		LOG.debug("useExpectContinue: {}", useExpectContinue);
 
 		
 		client = new StdHttpClient.Builder()


### PR DESCRIPTION
I've noticed that the HttpClientFactoryBean does not expose the expect continue option.  This is very important in a highly parallelized system. If you are leveraging locks / latches across threads that are blocking and waiting for the another thread to persist an entity so that it can then query it, the expect continue = true will tell the client to return thereby lifting a latching and allowing another thread to process (which is inaccurate behavior as couch will have not persisted yet, nor will it have updated its views).

Thanks.

Dan
