### PR TITLE
Fixed almost all of the Java warnings for org.ektorp

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/StreamingChangesResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/StreamingChangesResult.java
@@ -26,7 +26,7 @@ public class StreamingChangesResult implements Serializable, Iterable<DocumentCh
 	public StreamingChangesResult(ObjectMapper objectMapper, HttpResponse response) {
 		this.response = response;
         try{
-		    jp = objectMapper.getJsonFactory().createJsonParser(response.getContent());
+		    jp = objectMapper.getFactory().createParser(response.getContent());
 		    jp.nextValue();
 		    jp.nextValue();
 		    jp.nextToken();

--- a/org.ektorp/src/main/java/org/ektorp/http/PreemptiveAuthRequestInterceptor.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/PreemptiveAuthRequestInterceptor.java
@@ -34,8 +34,7 @@ public class PreemptiveAuthRequestInterceptor implements HttpRequestInterceptor 
             Credentials creds = credsProvider.getCredentials(authScope);
             // If found, generate BasicScheme preemptively
             if (creds != null) {
-                authState.setAuthScheme(new BasicScheme());
-                authState.setCredentials(creds);
+                authState.update(new BasicScheme(), creds);
             }
         }
     }

--- a/org.ektorp/src/main/java/org/ektorp/http/RestTemplate.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/RestTemplate.java
@@ -2,7 +2,6 @@ package org.ektorp.http;
 
 import java.io.InputStream;
 
-import org.ektorp.DbAccessException;
 import org.ektorp.util.Exceptions;
 /**
  * 

--- a/org.ektorp/src/main/java/org/ektorp/http/StdHttpClient.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/StdHttpClient.java
@@ -34,7 +34,6 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
@@ -503,7 +502,7 @@ public class StdHttpClient implements HttpClient {
 		public static org.apache.http.client.HttpClient withCaching(org.apache.http.client.HttpClient client, int maxCacheEntries, int maxObjectSizeBytes) {
 			CacheConfig cacheConfig = new CacheConfig();  
 			cacheConfig.setMaxCacheEntries(maxCacheEntries);
-			cacheConfig.setMaxObjectSizeBytes(maxObjectSizeBytes);
+			cacheConfig.setMaxObjectSize(maxObjectSizeBytes);
 			return new CachingHttpClient(client, cacheConfig);
 		}
 	}

--- a/org.ektorp/src/main/java/org/ektorp/impl/BulkDocumentWriter.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/BulkDocumentWriter.java
@@ -29,7 +29,7 @@ public class BulkDocumentWriter {
 	 */
 	public void write(Collection<?> objects, boolean allOrNothing, OutputStream out) {
 		try {
-			JsonGenerator jg = objectMapper.getJsonFactory().createJsonGenerator(out, JsonEncoding.UTF8);
+			JsonGenerator jg = objectMapper.getFactory().createGenerator(out, JsonEncoding.UTF8);
 			jg.writeStartObject();
 			if (allOrNothing) {
 				jg.writeBooleanField("all_or_nothing", true);
@@ -54,7 +54,7 @@ public class BulkDocumentWriter {
 
         try {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            JsonGenerator jg = objectMapper.getJsonFactory().createJsonGenerator(byteArrayOutputStream, JsonEncoding.UTF8);
+            JsonGenerator jg = objectMapper.getFactory().createGenerator(byteArrayOutputStream, JsonEncoding.UTF8);
             jg.writeStartObject();
             if (allOrNothing) {
                 jg.writeBooleanField("all_or_nothing", true);

--- a/org.ektorp/src/main/java/org/ektorp/impl/BulkOperationResponseHandler.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/BulkOperationResponseHandler.java
@@ -35,7 +35,7 @@ public class BulkOperationResponseHandler extends StdResponseHandler<List<Docume
 	@Override
 	public List<DocumentOperationResult> success(HttpResponse hr)
 			throws Exception {
-		JsonParser jp = objectMapper.getJsonFactory().createJsonParser(hr.getContent());
+		JsonParser jp = objectMapper.getFactory().createParser(hr.getContent());
 		List<DocumentOperationResult> result = new ArrayList<DocumentOperationResult>();
 		Iterator<?> objectsIter = objects == null ? null : objects.iterator();
 		while (jp.nextToken() != null) {

--- a/org.ektorp/src/main/java/org/ektorp/impl/DocIdResponseHandler.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/DocIdResponseHandler.java
@@ -20,12 +20,12 @@ public class DocIdResponseHandler extends StdResponseHandler<List<String>> {
 	private final JsonFactory jsonFactory;
 
 	public DocIdResponseHandler(ObjectMapper om) {
-		jsonFactory = om.getJsonFactory();
+		jsonFactory = om.getFactory();
 	}
 
 	@Override
 	public List<String> success(HttpResponse hr) throws Exception {
-		JsonParser jp = jsonFactory.createJsonParser(hr.getContent());
+		JsonParser jp = jsonFactory.createParser(hr.getContent());
 		if (jp.nextToken() != JsonToken.START_OBJECT) {
 			throw new DbAccessException("Expected data to start with an Object");
 		}

--- a/org.ektorp/src/main/java/org/ektorp/impl/docref/BackReferencedBeanDeserializer.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/docref/BackReferencedBeanDeserializer.java
@@ -1,20 +1,21 @@
 package org.ektorp.impl.docref;
 
-import java.io.*;
-import java.lang.reflect.*;
-import java.util.*;
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import org.ektorp.CouchDbConnector;
+import org.ektorp.docref.DocumentReferences;
+import org.ektorp.docref.FetchType;
+import org.ektorp.util.Documents;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.BeanDeserializer;
 import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import org.ektorp.*;
-import org.ektorp.docref.*;
-import org.ektorp.util.*;
 
 /**
  *

--- a/org.ektorp/src/main/java/org/ektorp/impl/docref/ViewBasedCollection.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/docref/ViewBasedCollection.java
@@ -105,7 +105,6 @@ public class ViewBasedCollection implements InvocationHandler {
 		collection.addAll(list);
 	}
 
-	@SuppressWarnings("unchecked")
 	public Object invoke(Object proxy, Method method, Object[] args)
 			throws Throwable {
 		if (method.getName().equals("set")) {

--- a/org.ektorp/src/main/java/org/ektorp/impl/jackson/EktorpBeanSerializerModifier.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/jackson/EktorpBeanSerializerModifier.java
@@ -3,19 +3,18 @@ package org.ektorp.impl.jackson;
 import java.lang.reflect.Field;
 import java.util.Collection;
 
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializationConfig;
-import com.fasterxml.jackson.databind.introspect.BasicBeanDescription;
-import com.fasterxml.jackson.databind.ser.BeanSerializer;
-import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
-
 import org.ektorp.CouchDbConnector;
 import org.ektorp.docref.CascadeType;
 import org.ektorp.docref.DocumentReferences;
 import org.ektorp.impl.docref.DocumentReferenceSerializer;
 import org.ektorp.util.Predicate;
 import org.ektorp.util.ReflectionUtils;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.ser.BeanSerializer;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 
 public class EktorpBeanSerializerModifier extends BeanSerializerModifier {
 

--- a/org.ektorp/src/main/java/org/ektorp/support/CouchDbRepositorySupport.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/CouchDbRepositorySupport.java
@@ -1,15 +1,24 @@
 package org.ektorp.support;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.ektorp.ComplexKey;
+import org.ektorp.CouchDbConnector;
+import org.ektorp.DocumentNotFoundException;
+import org.ektorp.Options;
+import org.ektorp.UpdateConflictException;
+import org.ektorp.ViewQuery;
+import org.ektorp.impl.NameConventions;
+import org.ektorp.util.Assert;
+import org.ektorp.util.Documents;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
-import org.ektorp.*;
-import org.ektorp.impl.*;
-import org.ektorp.util.*;
-import org.slf4j.*;
 
 /**
  * Provides "out of the box" CRUD functionality for sub classes.

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
@@ -153,6 +153,7 @@ public class StdCouchDbConnectorTest {
         assertEquals(12, getted.age);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetWithConflicts() {
         setupGetDocResponse();

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbInstanceTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbInstanceTest.java
@@ -59,6 +59,7 @@ public class StdCouchDbInstanceTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testGetFullConfiguration() {
 	    when(client.get("/_config")).thenReturn(HttpResponseStub.valueOf(200, "{\"httpd\": {" +
 	       "\"bind_address\": \"0.0.0.0\",\"port\": \"5984\"}, \"ssl\": {\"port\": \"6984\"}}"));
@@ -67,6 +68,7 @@ public class StdCouchDbInstanceTest {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testGetConfigurationSection() {
 		when(client.get("/_config/httpd")).thenReturn(HttpResponseStub.valueOf(200, "{\"httpd\": {" +
 			"\"bind_address\": \"0.0.0.0\",\"port\": \"5984\"}}"));

--- a/org.ektorp/src/test/java/org/ektorp/impl/changes/StdDocumentChangeTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/changes/StdDocumentChangeTest.java
@@ -89,6 +89,7 @@ public class StdDocumentChangeTest {
             Assert.assertEquals(++i, documentChange.getSequence());
         }
         Assert.assertEquals(5, changes.getLastSeq());
+        changes.close();
     }
 
 	private JsonNode load(String id) throws IOException {

--- a/org.ektorp/src/test/java/org/ektorp/support/AttachmentsInOrderParserTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/support/AttachmentsInOrderParserTest.java
@@ -38,7 +38,7 @@ public class AttachmentsInOrderParserTest
         InputStream attachmentsInputStream = getClass().getResourceAsStream("attachments.json");
 
         JsonFactory jsonFactory = new JsonFactory();
-        attachmentsJsonParser = jsonFactory.createJsonParser(attachmentsInputStream);
+        attachmentsJsonParser = jsonFactory.createParser(attachmentsInputStream);
 
         knownOrderList = Arrays.asList(KNOWN_ORDER);
     }

--- a/org.ektorp/src/test/java/org/ektorp/util/DocumentsTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/util/DocumentsTest.java
@@ -282,7 +282,6 @@ public class DocumentsTest {
 			return revisjon;
 		}
 
-		@SuppressWarnings("unused")
 		@JsonProperty("_rev")
 		private void setRevisjon(String revisjon) {
 			this.revisjon = revisjon;


### PR DESCRIPTION
Mostly updating away from deprecated APIs and fixing imports, some other small bits and pieces

Only remaining warnings are for JSON deserialization, where the current deserialization doesn't consider the cases for any tokens other than the expected ones, which is probably a slightly bigger and separate job to fix. Any enthusiasm for me doing that, or not too bothered?
