### PR TITLE
enable getting string format since

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/changes/DocumentChange.java
+++ b/org.ektorp/src/main/java/org/ektorp/changes/DocumentChange.java
@@ -15,6 +15,10 @@ public interface DocumentChange {
 	 */
 	int getSequence();
 	/**
+	 * @return the database string format sequence number in which this change took place (e.g. Cloudant).
+	 */
+	String getStringSequence();
+	/**
 	 *
 	 * @return the id of the changed document.
 	 */

--- a/org.ektorp/src/main/java/org/ektorp/impl/changes/StdDocumentChange.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/changes/StdDocumentChange.java
@@ -33,6 +33,10 @@ public class StdDocumentChange implements DocumentChange {
 		return node.get(SEQ_FIELD_NAME).intValue();
 	}
 
+	public String getStringSequence() {
+		return node.get(SEQ_FIELD_NAME).textValue();
+	}
+
 	public String getId() {
 		return node.get(ID_FIELD_NAME).textValue();
 	}


### PR DESCRIPTION
CouchDB based Cloudant requires String format sequence number handling for "seq" as follows:

acurl https://jerryj3.cloudant.com/a_event/_changes?feed=continuous
...
{"seq":"625-g1AAAAETeJzLYWBgYMlgTmGQTUlKzi9KdUhJMtMrzsnMS9dLzskvTUnMK9HLSy3JASpjSmRIsv___39WBlPimlygALu5iWGiWWoSkdqTHIBkUj3UhLlgE5JSTc2M0og1IY8FSDI0ACmgIftBpkwEm2JmZmmSZJRIkikHIKaA3TIdbIpBool5ioFxFgB5VlYa","id":"2af9308494fcf09851b068f87acc2a15","changes":[{"rev":"1-b62ae1ce985a636ef11809ba37b0fb18"}]}
...
