### PR TITLE
introducing FindBugs maven plugin 

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/Attachment.java
+++ b/org.ektorp/src/main/java/org/ektorp/Attachment.java
@@ -24,7 +24,10 @@ public class Attachment implements Serializable {
 	private String dataBase64;
 	private boolean stub;
 	private int revpos;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "UWF_UNWRITTEN_FIELD")
 	private String digest;
+
 	private Map<String, Object> anonymous;
 
 	/**
@@ -38,6 +41,7 @@ public class Attachment implements Serializable {
 	 * @param contentType
 	 * @param contentLength
 	 */
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "DM_DEFAULT_ENCODING")
 	public Attachment(String id, String data, String contentType) {
 		Assert.hasText(id, "attachmentId must have a value");
 		Assert.hasText(contentType, "contentType must have a value");

--- a/org.ektorp/src/main/java/org/ektorp/PageRequest.java
+++ b/org.ektorp/src/main/java/org/ektorp/PageRequest.java
@@ -27,6 +27,7 @@ public class PageRequest {
 	private final boolean back;
 	private final int page;
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="DB_DUPLICATE_BRANCHES")
 	public static ViewQuery applyPagingParameters(ViewQuery q, PageRequest pr) {
 		ViewQuery pagedQuery = q.clone();
 		if (pr.page > 0) {

--- a/org.ektorp/src/main/java/org/ektorp/ReplicationStatus.java
+++ b/org.ektorp/src/main/java/org/ektorp/ReplicationStatus.java
@@ -27,9 +27,11 @@ public class ReplicationStatus implements Serializable {
 	String sessionId;
 
 	@JsonProperty("source_last_seq")
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
 	JsonNode sourceLastSequence;
 
 	@JsonProperty("history")
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
 	List<History> history;
 
 	private Map<String, Object> unknownFields;

--- a/org.ektorp/src/main/java/org/ektorp/ReplicatorDocument.java
+++ b/org.ektorp/src/main/java/org/ektorp/ReplicatorDocument.java
@@ -72,6 +72,8 @@ public class ReplicatorDocument extends CouchDbDocument
     private Collection<String> documentIds;
     private String filter;
     private Object queryParameters;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
     private UserContext userContext;
 
     private String replicationId;

--- a/org.ektorp/src/main/java/org/ektorp/StreamingChangesResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/StreamingChangesResult.java
@@ -20,9 +20,15 @@ public class StreamingChangesResult implements Serializable, Iterable<DocumentCh
 
 	private static final long serialVersionUID = 4750290767936801714L;
 	private boolean iteratorCalled;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
 	private JsonParser jp;
+
 	private long lastSeq = -1l;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
     private final HttpResponse response;
+
 	public StreamingChangesResult(ObjectMapper objectMapper, HttpResponse response) {
 		this.response = response;
         try{

--- a/org.ektorp/src/main/java/org/ektorp/StreamingViewResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/StreamingViewResult.java
@@ -23,13 +23,18 @@ public class StreamingViewResult implements Serializable, Iterable<Row>, Closeab
 	private static final long serialVersionUID = 4750290767936801714L;
 	private int totalRows = -1;
 	private int offset = -1;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
 	private final BufferedReader reader;
+
 	private final ObjectMapper objectMapper;
 	private boolean iteratorCalled;
     private final boolean ignoreNotFound;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
     private final HttpResponse httpResponse;
 
-
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"DM_DEFAULT_ENCODING", "NP_DEREFERENCE_OF_READLINE_VALUE"})
 	public StreamingViewResult(ObjectMapper objectMapper, HttpResponse httpResponse, boolean ignoreNotFound) {
 
 		this.objectMapper = objectMapper;

--- a/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
@@ -664,6 +664,7 @@ public class ViewQuery {
 		return query;
 	}
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"SA_FIELD_SELF_ASSIGNMENT", "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE"})
 	public ViewQuery clone() {
 		ViewQuery copy = new ViewQuery();
 		copy.mapper = mapper;
@@ -904,6 +905,7 @@ public class ViewQuery {
             return Collections.unmodifiableList(keys);
 		}
 		
+        @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE")
 		public Keys clone() {
 			return new Keys(keys);
 		}

--- a/org.ektorp/src/main/java/org/ektorp/ViewResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewResult.java
@@ -25,6 +25,8 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 	private int totalRows = -1;
 	private int offset = -1;
 	private String updateSeq;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
 	private List<Row> rows;
 
 	public ViewResult(JsonNode resultNode, boolean ignoreNotFound) {

--- a/org.ektorp/src/main/java/org/ektorp/http/IdleConnectionMonitor.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/IdleConnectionMonitor.java
@@ -46,6 +46,7 @@ public class IdleConnectionMonitor {
             thisFuture = future;
         }
 
+        @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
         public void run() {
             if (cm.get() != null) {
                 cm.get().closeExpiredConnections();

--- a/org.ektorp/src/main/java/org/ektorp/http/JacksonableEntity.java
+++ b/org.ektorp/src/main/java/org/ektorp/http/JacksonableEntity.java
@@ -17,6 +17,7 @@ import java.io.*;
  * @see org.apache.http.entity.SerializableEntity
  */
 @NotThreadSafe
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "HE_EQUALS_USE_HASHCODE")
 public class JacksonableEntity extends AbstractHttpEntity {
 
     private byte[] objSer;

--- a/org.ektorp/src/main/java/org/ektorp/impl/BulkOperationResponseHandler.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/BulkOperationResponseHandler.java
@@ -33,6 +33,7 @@ public class BulkOperationResponseHandler extends StdResponseHandler<List<Docume
 	}
 
 	@Override
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SF_SWITCH_NO_DEFAULT")
 	public List<DocumentOperationResult> success(HttpResponse hr)
 			throws Exception {
 		JsonParser jp = objectMapper.getFactory().createParser(hr.getContent());

--- a/org.ektorp/src/main/java/org/ektorp/impl/PageResponseHandler.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/PageResponseHandler.java
@@ -42,6 +42,7 @@ public class PageResponseHandler<T> extends StdResponseHandler<Page<T>> {
 	}
 	
 	@Override
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="DB_DUPLICATE_BRANCHES")
 	public Page<T> success(HttpResponse hr) throws Exception {
 		parser.parseResult(hr.getContent());
 		List<T> rows = parser.getRows();

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdActiveTask.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdActiveTask.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
    @Type(value = StdIndexerTask.class, name = "indexer"),
    @Type(value = StdDatabaseCompactionTask.class, name = "database_compaction"),
    @Type(value = StdViewCompactionTask.class, name = "view_compaction") })
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "EI_EXPOSE_REP")
 public abstract class StdActiveTask implements ActiveTask {
 
     private String pid;

--- a/org.ektorp/src/main/java/org/ektorp/impl/changes/ContinuousChangesFeed.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/changes/ContinuousChangesFeed.java
@@ -89,6 +89,7 @@ public final class ContinuousChangesFeed implements ChangesFeed, Runnable {
 		thread.interrupt();
 	}
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
 	private void sendInterruptMarker()  {
 		LOG.debug("Sending interrupt marker in order to interrupt feed consumer");
 		changes.offer(INTERRUPT_MARKER);

--- a/org.ektorp/src/main/java/org/ektorp/impl/docref/BackReferencedBeanDeserializer.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/docref/BackReferencedBeanDeserializer.java
@@ -27,7 +27,10 @@ public class BackReferencedBeanDeserializer extends StdDeserializer<Object>
 
 	private final CouchDbConnector couchDbConnector;
 	private final BeanDeserializer delegate;
+
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
 	private final List<ConstructibleAnnotatedCollection> backReferencedFields;
+
 	private final Class<?> clazz;
 
 	public BackReferencedBeanDeserializer(BeanDeserializer deserializer,

--- a/org.ektorp/src/main/java/org/ektorp/impl/docref/DocumentReferenceSerializer.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/docref/DocumentReferenceSerializer.java
@@ -99,6 +99,7 @@ public class DocumentReferenceSerializer extends JsonSerializer<Object> {
 		throw new DbAccessException(sb.toString());
 	}
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="BC_VACUOUS_INSTANCEOF")
 	private Set<?> findDocumentsToSave(Set<?> o) {
 		if (o == null) {
 			return Collections.emptySet();

--- a/org.ektorp/src/main/java/org/ektorp/impl/docref/ViewBasedCollection.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/docref/ViewBasedCollection.java
@@ -105,6 +105,7 @@ public class ViewBasedCollection implements InvocationHandler {
 		collection.addAll(list);
 	}
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="BC_BAD_CAST_TO_ABSTRACT_COLLECTION")
 	public Object invoke(Object proxy, Method method, Object[] args)
 			throws Throwable {
 		if (method.getName().equals("set")) {
@@ -188,6 +189,7 @@ public class ViewBasedCollection implements InvocationHandler {
 		return false;
 	}
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="BC_BAD_CAST_TO_ABSTRACT_COLLECTION")
 	public class RememberRemovedListIterator implements ListIterator<Object> {
 
 		@SuppressWarnings("unchecked")

--- a/org.ektorp/src/main/java/org/ektorp/support/DesignDocument.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/DesignDocument.java
@@ -31,7 +31,9 @@ public class DesignDocument extends OpenCouchDbDocument {
     public static final String AUTO_UPDATE_VIEW_ON_CHANGE = "org.ektorp.support.AutoUpdateViewOnChange";
     public static final String UPDATE_ON_DIFF = "org.ektorp.support.UpdateDesignDocOnDiff";
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="SE_BAD_FIELD")
     private Map<String, View> views;
+
     private Map<String, String> lists;
     private Map<String, String> shows;
     private Map<String, String> updateHandlers;

--- a/org.ektorp/src/main/java/org/ektorp/support/SimpleViewGenerator.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/SimpleViewGenerator.java
@@ -130,6 +130,7 @@ public class SimpleViewGenerator {
 				});
 	}
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="VA_FORMAT_STRING_EXTRA_ARGUMENTS_PASSED")
 	private String resolveTypeDiscriminator(final Class<?> persistentType) {
 		final List<String> discrimintators = new ArrayList<String>();
 		TypeDiscriminator td = persistentType

--- a/org.ektorp/src/main/java/org/ektorp/util/Base64.java
+++ b/org.ektorp/src/main/java/org/ektorp/util/Base64.java
@@ -667,6 +667,7 @@ public class Base64
      * @throws IllegalArgumentException if source array, offset, or length are invalid
      * @since 2.0
      */
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "DM_DEFAULT_ENCODING")
     public static String encodeBytes( byte[] source, int off, int len, int options ) throws java.io.IOException {
         byte[] encoded = encodeBytesToBytes( source, off, len, options );
 
@@ -720,6 +721,7 @@ public class Base64
      * @throws IllegalArgumentException if source array, offset, or length are invalid
      * @since 2.3.1
      */
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"DE_MIGHT_IGNORE"})
     public static byte[] encodeBytesToBytes( byte[] source, int off, int len, int options ) throws java.io.IOException {
 
         if( source == null ){
@@ -1074,6 +1076,7 @@ public class Base64
      * @throws NullPointerException if <tt>s</tt> is null
      * @since 1.4
      */
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"DM_DEFAULT_ENCODING", "DE_MIGHT_IGNORE"})
     public static byte[] decode( String s, int options ) throws java.io.IOException {
         
         if( s == null ){

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
         <httpclient.version>4.3</httpclient.version>
         <aspectj.version>1.6.9</aspectj.version>
         <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
+
+        <findbugs.skip>false</findbugs.skip>
+        <findbugs.includeTests>false</findbugs.includeTests>
     </properties>
 
     <dependencyManagement>
@@ -124,8 +127,30 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>net.sourceforge.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <defaultGoal>install</defaultGoal>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>${sonarVersion}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -162,6 +187,26 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>${findbugs.skip}</skip>
+                    <fork>true</fork>
+                    <includeTests>${findbugs.includeTests}</includeTests>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -222,6 +267,31 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>maven-2</id>
+            <activation>
+                <file>
+                    <!-- basedir expression is only recognized by Maven 3.x (see MNG-2363) -->
+                    <missing>${basedir}</missing>
+                </file>
+            </activation>
+            <properties>
+                <sonarVersion>1.0</sonarVersion>
+            </properties>
+        </profile>
+        <profile>
+            <id>maven-3</id>
+            <activation>
+                <file>
+                    <!-- basedir expression is only recognized by Maven 3.x (see MNG-2363) -->
+                    <exists>${basedir}</exists>
+                </file>
+            </activation>
+            <properties>
+                <sonarVersion>2.1</sonarVersion>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
to monitor production code for bugs/warnings + added annotations to SuppressWarnings on all existing warnings in production code (no warnings is actually fixed in this commit) + set the maven property findbugs.skip to false by default so that TravisCI will execute it; still UnitTests are not yet covered by FindBugs

also added sonar plugin declaration to make it possible to use sonar with recent version of both maven and sonar (I should have done this one in a separate commit)
