### PR TITLE
Spring shutdown listener

### DIFF
--- a/org.ektorp.spring/src/main/java/org/ektorp/spring/ShutdownListener.java
+++ b/org.ektorp.spring/src/main/java/org/ektorp/spring/ShutdownListener.java
@@ -6,7 +6,13 @@ import org.springframework.context.event.ContextClosedEvent;
 
 /**
  * Provides proper shutdown for Ektorp within a Spring application context.
-
+ *
+ * Add the following line to your Spring application context.
+ * <pre>
+ * {@code
+ * <bean class="org.ektorp.spring.ShutdownListener"/> }
+ * </pre>
+ *
  * @author David Venable
  */
 public class ShutdownListener implements ApplicationListener<ContextClosedEvent>


### PR DESCRIPTION
If you use Ektorp in a Spring web application, when the application context shuts down, the container will have a memory leak because Ektorp does not shutdown.

I've created a simple class which lets you easily shutdown Ektorp when the application context shuts down. We have used this extensively to allow hot deployments in Tomcat without memory leaks.
