### PR TITLE
Support for prodiving a HttpEntity to save a couchdb attachement

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/CouchDbConnector.java
@@ -9,6 +9,7 @@ import org.ektorp.changes.ChangesCommand;
 import org.ektorp.changes.ChangesFeed;
 import org.ektorp.changes.DocumentChange;
 import org.ektorp.http.HttpClient;
+import org.ektorp.impl.AttachmentCouchDbConnector;
 
 /**
  * Primary interface for working with Objects mapped as documents in CouchDb.
@@ -18,7 +19,7 @@ import org.ektorp.http.HttpClient;
  * @author henrik lundgren
  * 
  */
-public interface CouchDbConnector extends LocalBulkBuffer {
+public interface CouchDbConnector extends LocalBulkBuffer, AttachmentCouchDbConnector {
     /**
      * 
      * @param id

--- a/org.ektorp/src/main/java/org/ektorp/impl/AttachmentCouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/AttachmentCouchDbConnector.java
@@ -1,5 +1,6 @@
 package org.ektorp.impl;
 
+import org.apache.http.HttpEntity;
 import org.ektorp.AttachmentInputStream;
 
 public interface AttachmentCouchDbConnector {
@@ -7,6 +8,10 @@ public interface AttachmentCouchDbConnector {
     String createAttachment(String docId, AttachmentInputStream data);
 
     String createAttachment(String docId, String revision, AttachmentInputStream data);
+
+    String createAttachment(String docId, HttpEntity attachmentEntity, String attachmentName);
+
+    String createAttachment(String docId, String revision, HttpEntity attachmentEntity, String attachmentName);
 
     AttachmentInputStream getAttachment(String id, String attachmentId);
 

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdAttachmentCouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdAttachmentCouchDbConnector.java
@@ -1,5 +1,6 @@
 package org.ektorp.impl;
 
+import org.apache.http.HttpEntity;
 import org.ektorp.AttachmentInputStream;
 import org.ektorp.http.HttpResponse;
 import org.ektorp.http.RestTemplate;
@@ -37,6 +38,21 @@ public class StdAttachmentCouchDbConnector implements AttachmentCouchDbConnector
             uri.param("rev", revision);
         }
         return restTemplate.put(uri.toString(), data, data.getContentType(), data.getContentLength(), revisionHandler).getRevision();
+    }
+
+    @Override
+    public String createAttachment(String docId, HttpEntity attachmentEntity, String attachmentName) {
+        return createAttachment(docId, null, attachmentEntity, attachmentName);
+    }
+
+    @Override
+    public String createAttachment(String docId, String revision, HttpEntity attachmentEntity, String attachmentName) {
+        assertDocIdHasValue(docId);
+        URI uri = dbURI.append(docId).append(attachmentName);
+        if (revision != null) {
+            uri.param("rev", revision);
+        }
+        return restTemplate.put(uri.toString(), attachmentEntity, revisionHandler).getRevision();
     }
 
     @Override

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbConnector.java
@@ -14,6 +14,7 @@ import org.apache.commons.io.IOUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
 import org.ektorp.*;
 import org.ektorp.changes.ChangesCommand;
 import org.ektorp.changes.ChangesFeed;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author henrik lundgren
  *
  */
-public class StdCouchDbConnector implements CouchDbConnector, AttachmentCouchDbConnector {
+public class StdCouchDbConnector implements CouchDbConnector {
 
     private static final int DEFAULT_HEARTBEAT_INTERVAL = 9000;
     private static final Logger LOG = LoggerFactory
@@ -193,6 +194,16 @@ public class StdCouchDbConnector implements CouchDbConnector, AttachmentCouchDbC
     @Override
     public String createAttachment(String docId, String revision, AttachmentInputStream data) {
         return attachmentCouchDbConnector.createAttachment(docId, revision, data);
+    }
+
+    @Override
+    public String createAttachment(String docId, HttpEntity attachmentEntity, String attachmentName) {
+        return attachmentCouchDbConnector.createAttachment(docId, attachmentEntity, attachmentName);
+    }
+
+    @Override
+    public String createAttachment(String docId, String revision, HttpEntity attachmentEntity, String attachmentName) {
+        return attachmentCouchDbConnector.createAttachment(docId, revision, attachmentEntity, attachmentName);
     }
 
     @Override


### PR DESCRIPTION
This change provides a new method
in order to be able to publish an attachment document to couchdb providing an HttpEntity

this is usefull when the application does not have an InputStream to provide to the existing methods.
but have an Object that is able to be written to an OutputStream

without relying on a temporary ByteArrayOutputStream buffer (or similar)

About implementation details :  
The first commit is a refactoring : I extracted all the methods related to attachment management into a new class StdAttachmentCouchDbConnector, and a matching AttachmentCouchDbConnector interface.

I made CouchDbConnector extend AttachmentCouchDbConnector in order to save code duplication. 
And StdCouchDbConnector is encapsulating the StdAttachmentCouchDbConnector instance.

Still, I am unsure whether or not CouchDbConnector should extend AttachmentCouchDbConnector, or if we would better have code duplication.
This is because there may be some kind of leaking abstraction exposing HttpEntity in the CouchDbConnector interface. Or maybe we should not care ?

I'll leave it up to you to comment on this.
