### PR TITLE
should check that the database does not exist before attempting to create it

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbInstance.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdCouchDbInstance.java
@@ -60,6 +60,10 @@ public class StdCouchDbInstance implements CouchDbInstance {
 	}
 
 	public boolean createDatabaseIfNotExists(final DbPath db) {
+		boolean databaseAlreadyExists = checkIfDbExists(db);
+		if (databaseAlreadyExists) {
+			return false;
+		}
 		LOG.debug("creating db path: {}", db.getPath());
 		return restTemplate.put(db.getPath(), new StdResponseHandler<Boolean>() {
 			@Override
@@ -83,7 +87,7 @@ public class StdCouchDbInstance implements CouchDbInstance {
 		Assert.notNull(path);
 		restTemplate.delete(DbPath.fromString(path).getPath());
 	}
-	
+
 	@Override
 	public boolean checkIfDbExists(String path) {
 	    return checkIfDbExists(DbPath.fromString(path));

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdCouchDbConnectorTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.internal.stubbing.answers.ThrowsException;
+import org.mockito.internal.verification.VerificationModeFactory;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -235,6 +236,7 @@ public class StdCouchDbConnectorTest {
 
     @Test
     public void should_create_db_if_missing() {
+        doReturn(HttpResponseStub.valueOf(404, "{\"error\":\"not_found\",\"reason\":\"no_db_file\"}")).when(httpClient).head("/test_db/");
 		doReturn(HttpResponseStub.valueOf(HttpStatus.CREATED, null)).when(httpClient).put("/test_db/");
 		dbCon.createDatabaseIfNotExists();
 		verify(httpClient).put("/test_db/");
@@ -242,9 +244,14 @@ public class StdCouchDbConnectorTest {
 
     @Test
     public void should_not_create_db_if_already_exists() {
-		doReturn(HttpResponseStub.valueOf(HttpStatus.PRECONDITION_FAILED, null)).when(httpClient).put("/test_db/");
-		dbCon.createDatabaseIfNotExists();
-		verify(httpClient).put("/test_db/");
+        doReturn(HttpResponseStub
+                .valueOf(
+                        200,
+                        "{\"test_db\":\"global\",\"doc_count\":1,\"doc_del_count\":0,\"update_seq\":3,\"purge_seq\":0,\"compact_running\":false,\"disk_size\":100,\"instance_start_time\":\"130\",\"disk_format_version\":5,\"committed_update_seq\":3}"))
+                .when(httpClient).head("/test_db/");
+
+        dbCon.createDatabaseIfNotExists();
+        verify(httpClient, VerificationModeFactory.times(0)).put(anyString());
     }
 
     @Test


### PR DESCRIPTION
changed back unit tests to previous behavior + fixed code accordingly

Since #186 the code of createDatabaseIfNotExists() does not longer check if the database exists but just attempt to create it and check for the return code of the DB.
This is changing an existing behavior and could break at existing users of Ektorp and Cloudant Big Couch.
Cloudant forbidds the usage of the CouchDB API to create a new database. Applications should have their Databases already created. Applications using createDatabaseIfNotExists() should then not attempt to create the database, but should find that the database already exists and just proceed.
When the same application runs on a CouchDB service where the database does not exist, then it should find the database does not exists and create it.

Ektorp should keep on checking if the DB already exists before attempting to create it.
However, the code introduced in #186 to ignore the 412 error code if the DB already was created concurrently stays accurate. 
