### PR TITLE
Fixed bug in ViewQuery clone() method

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
@@ -738,7 +738,7 @@ public class ViewQuery {
 		copy.listName = listName;
 		copy.queryParams.putAll(queryParams);
 		copy.reduce = reduce;
-		copy.skip = copy.skip;
+		copy.skip = skip;
 		copy.staleOk = staleOk;
 		copy.startDocId = startDocId;
 		startKey.copyTo(startKey);


### PR DESCRIPTION
the skip property was not clone as expected
