### PR TITLE
fixed bug in ViewQuery.clone() + fixed regression in getKey() getStartKey() getEndKey() methods

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
@@ -1,5 +1,6 @@
 package org.ektorp;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -61,6 +62,14 @@ public class ViewQuery {
 				} catch (Exception e) {
 					throw Exceptions.propagate(e);
 				}
+			}
+		}
+
+		public Object asDecoded() {
+			if (isRaw) {
+				return parseJson(rawKey);
+			} else {
+				return key;
 			}
 		}
 
@@ -612,7 +621,7 @@ public class ViewQuery {
 	}
 
 	public Object getKey() {
-		return key;
+		return key.asDecoded();
 	}
 
     public boolean hasMultipleKeys() {
@@ -628,11 +637,11 @@ public class ViewQuery {
 
 
     public Object getStartKey() {
-		return startKey;
+		return startKey.asDecoded();
 	}
 
 	public Object getEndKey() {
-		return endKey;
+		return endKey.asDecoded();
 	}
 
 	public String buildQuery() {
@@ -741,7 +750,7 @@ public class ViewQuery {
 		copy.skip = copy.skip;
 		copy.staleOk = staleOk;
 		copy.startDocId = startDocId;
-		startKey.copyTo(startKey);
+		startKey.copyTo(copy.startKey);
 		copy.updateSeq = updateSeq;
 		copy.viewName = viewName;
 		return copy;

--- a/org.ektorp/src/test/java/org/ektorp/ViewQueryCloneTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/ViewQueryCloneTest.java
@@ -1,0 +1,111 @@
+package org.ektorp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class ViewQueryCloneTest {
+
+
+	@Test
+	public void cloneShouldCopyStartRawKey() throws IOException {
+		String inputRawKey = "\"hello\"";
+		Object expectedResult = new ObjectMapper().readTree(inputRawKey);
+		ViewQuery q = new ViewQuery();
+		q.rawStartKey(inputRawKey);
+		assertEquals(expectedResult, q.getStartKey());
+		ViewQuery clone = q.clone();
+		assertEquals(expectedResult, clone.getStartKey());
+	}
+
+	@Test
+	public void cloneShouldCopyEndRawKey() throws IOException {
+		String inputRawKey = "\"hello\"";
+		Object expectedResult = new ObjectMapper().readTree(inputRawKey);
+		ViewQuery q = new ViewQuery();
+		q.rawEndKey(inputRawKey);
+		assertEquals(expectedResult, q.getEndKey());
+		ViewQuery clone = q.clone();
+		assertEquals(expectedResult, clone.getEndKey());
+	}
+
+	@Test
+	public void cloneShouldCopyRawKey() throws IOException {
+		String inputRawKey = "\"hello\"";
+		Object expectedResult = new ObjectMapper().readTree(inputRawKey);
+		ViewQuery q = new ViewQuery();
+		q.rawKey(inputRawKey);
+		assertEquals(expectedResult, q.getKey());
+		ViewQuery clone = q.clone();
+		assertEquals(expectedResult, clone.getKey());
+	}
+
+	@Test
+	public void cloneShouldCopyStartKey() {
+		Object inputKeyObject = "hello";
+		ViewQuery q = new ViewQuery();
+		q.startKey(inputKeyObject);
+		assertEquals(inputKeyObject, q.getStartKey());
+		ViewQuery clone = q.clone();
+		assertEquals(inputKeyObject, clone.getStartKey());
+	}
+
+	@Test
+	public void cloneShouldCopyEndKey() {
+		Object inputKeyObject = "hello";
+		ViewQuery q = new ViewQuery();
+		q.endKey(inputKeyObject);
+		assertEquals(inputKeyObject, q.getEndKey());
+		ViewQuery clone = q.clone();
+		assertEquals(inputKeyObject, clone.getEndKey());
+	}
+
+	@Test
+	public void cloneShouldCopyKey() {
+		Object inputKeyObject = "hello";
+		ViewQuery q = new ViewQuery();
+		q.key(inputKeyObject);
+		assertEquals(inputKeyObject, q.getKey());
+		ViewQuery clone = q.clone();
+		assertEquals(inputKeyObject, clone.getKey());
+	}
+
+	@Test
+	public void cloneShouldCopyStartKeyWithSameInstance() {
+		Object inputKeyObject = new Object();
+		ViewQuery q = new ViewQuery();
+		q.startKey(inputKeyObject);
+		assertEquals(inputKeyObject, q.getStartKey());
+		ViewQuery clone = q.clone();
+		assertEquals(inputKeyObject, clone.getStartKey());
+		assertSame(inputKeyObject, clone.getStartKey());
+	}
+
+	@Test
+	public void cloneShouldCopyEndKeyWithSameInstance() {
+		Object inputKeyObject = new Object();
+		ViewQuery q = new ViewQuery();
+		q.endKey(inputKeyObject);
+		assertEquals(inputKeyObject, q.getEndKey());
+		ViewQuery clone = q.clone();
+		assertEquals(inputKeyObject, clone.getEndKey());
+		assertSame(inputKeyObject, clone.getEndKey());
+	}
+
+	@Test
+	public void cloneShouldCopyKeyWithSameInstance() {
+		Object inputKeyObject = new Object();
+		ViewQuery q = new ViewQuery();
+		q.key(inputKeyObject);
+		assertEquals(inputKeyObject, q.getKey());
+		ViewQuery clone = q.clone();
+		assertEquals(inputKeyObject, clone.getKey());
+		assertSame(inputKeyObject, clone.getKey());
+	}
+
+
+}


### PR DESCRIPTION
those bugs were introduced in issue #181
