### PR TITLE
Turn off doclint so project javadocs can be built in Java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,14 @@
                 </executions>
             </plugin>
             <plugin>
+                <!-- http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html -->
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.1</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Turn off doclint so project javadocs can be built in Java8, see http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
