### PR TITLE
No NullPointerException by ViewResult.Row.getId() when ID property is missing

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ViewResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewResult.java
@@ -154,7 +154,11 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 		}
 
 		public String getId() {
-			return rowNode.get(ID_FIELD_NAME).textValue();
+			return nodeAsString(getIdAsNode());
+		}
+
+		public JsonNode getIdAsNode() {
+			return rowNode.findPath(ID_FIELD_NAME);
 		}
 
 		public String getKey() {

--- a/org.ektorp/src/test/java/org/ektorp/ViewResultTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/ViewResultTest.java
@@ -5,7 +5,10 @@ import static org.junit.Assert.*;
 import java.io.InputStream;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
 
@@ -39,6 +42,24 @@ public class ViewResultTest {
         assertEquals(4, rows.get(0).getValueAsInt());
         assertEquals(5, rows.get(1).getValueAsInt());
         assertEquals(6, rows.get(2).getValueAsInt());
+
+    }
+
+    @Test
+    public void test_read_grouped_result() throws Exception {
+        ViewResult result = readResult("impl/group_view_result.json");
+        assertEquals(2, result.getSize());
+        List<ViewResult.Row> rows = result.getRows();
+        
+        assertEquals(null, rows.get(0).getIdAsNode().textValue());
+
+        assertEquals(null, rows.get(0).getId());
+        assertEquals("h", rows.get(0).getKey());
+        assertEquals(2, rows.get(0).getValueAsInt());
+
+        assertEquals(null, rows.get(0).getId());
+        assertEquals("m", rows.get(1).getKey());
+        assertEquals(1, rows.get(1).getValueAsInt());
 
     }
 

--- a/org.ektorp/src/test/resources/org/ektorp/impl/group_view_result.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/group_view_result.json
@@ -1,0 +1,4 @@
+{"rows":[
+{"key":"h","value":2},
+{"key":"m","value":1}
+]}


### PR DESCRIPTION
added: method ViewResult.Row.getIdAsNode()
  so that it is possible to find out whether or not an ID property exists
changed: method ViewResult.Row.getId()
  so that the method does not throw a NullPointerException when there is no property 'id'

This is useful when (A) the view result is grouped or reduced
and (B) the client code is generic so that it does not know whether
or not the view result contains an ID property.