### PR TITLE
fix to issue #220

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ReplicationTask.java
+++ b/org.ektorp/src/main/java/org/ektorp/ReplicationTask.java
@@ -75,4 +75,10 @@ public interface ReplicationTask extends ActiveTask {
      * @return the latest sequence number of the source database which has been processed by this task
      */
     long getCheckpointedSourceSequenceId();
+
+	/**
+	 * Defines replication checkpoint interval in milliseconds. Replicator will requests from the Source database at the specified interval
+	 */
+	Long getCheckpointInterval();
+
 }

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdReplicationTask.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdReplicationTask.java
@@ -17,6 +17,7 @@ public class StdReplicationTask extends StdActiveTask implements ReplicationTask
     private String sourceDatabase;
     private String targetDatabase;
     private long sourceSequenceId;
+    private Long checkpointInterval;
     private long checkpointedSourceSequenceId;
 
     @Override
@@ -139,4 +140,13 @@ public class StdReplicationTask extends StdActiveTask implements ReplicationTask
         this.checkpointedSourceSequenceId = checkpointedSourceSequenceId;
     }
 
+	@Override
+	public Long getCheckpointInterval() {
+		return checkpointInterval;
+	}
+
+	@JsonProperty(required = false, value = "checkpoint_interval")
+	public void setCheckpointInterval(Long checkpointInterval) {
+		this.checkpointInterval = checkpointInterval;
+	}
 }

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdReplicationTaskTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdReplicationTaskTest.java
@@ -1,0 +1,81 @@
+package org.ektorp.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.ektorp.ActiveTask;
+import org.ektorp.ReplicationTask;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class StdReplicationTaskTest {
+
+	@Test
+	public void shouldParseValidStdReplicationTaskWithCheckpointInterval() throws IOException {
+		final String resourceName = "replication_task_sample_with_checkpointinterval.json";
+		ActiveTask activeTask = readResourceAsActiveTask(resourceName);
+		assertNotNull(activeTask);
+		ReplicationTask replicationTask = (ReplicationTask) activeTask;
+		assertEquals("0.992.0>", replicationTask.getPid());
+		assertEquals(Long.valueOf(5000l), replicationTask.getCheckpointInterval());
+		assertEquals(95948, replicationTask.getCheckpointedSourceSequenceId());
+		assertEquals(true, replicationTask.isContinuous());
+		assertEquals(null, replicationTask.getReplicationDocumentId());
+		assertEquals(0, replicationTask.getWriteFailures());
+		assertEquals(8, replicationTask.getTotalReads());
+		assertEquals(8, replicationTask.getTotalWrites());
+		assertEquals(8, replicationTask.getTotalMissingRevisions());
+		assertEquals(100, replicationTask.getProgress());
+		assertEquals("cc86d412959b7c453ab661ce23312db7+continuous", replicationTask.getReplicationId());
+		assertEquals(777, replicationTask.getTotalRevisionsChecked());
+		assertEquals("sourceDB", replicationTask.getSourceDatabaseName());
+		assertEquals(373378, replicationTask.getSourceSequenceId());
+		assertEquals(1422566612, replicationTask.getStartedOn().getTime());
+		assertEquals("targetDB", replicationTask.getTargetDatabaseName());
+		assertEquals(1422581543, replicationTask.getUpdatedOn().getTime());
+	}
+
+	@Test
+	public void shouldParseValidStdReplicationTaskWithoutCheckpointInterval() throws IOException {
+		final String resourceName = "replication_task_sample_without_checkpointinterval.json";
+		ActiveTask activeTask = readResourceAsActiveTask(resourceName);
+		assertNotNull(activeTask);
+		ReplicationTask replicationTask = (ReplicationTask) activeTask;
+		assertEquals("0.992.0>", replicationTask.getPid());
+		assertEquals(null, replicationTask.getCheckpointInterval());
+		assertEquals(95948, replicationTask.getCheckpointedSourceSequenceId());
+		assertEquals(true, replicationTask.isContinuous());
+		assertEquals(null, replicationTask.getReplicationDocumentId());
+		assertEquals(0, replicationTask.getWriteFailures());
+		assertEquals(8, replicationTask.getTotalReads());
+		assertEquals(8, replicationTask.getTotalWrites());
+		assertEquals(8, replicationTask.getTotalMissingRevisions());
+		assertEquals(100, replicationTask.getProgress());
+		assertEquals("cc86d412959b7c453ab661ce23312db7+continuous", replicationTask.getReplicationId());
+		assertEquals(777, replicationTask.getTotalRevisionsChecked());
+		assertEquals("sourceDB", replicationTask.getSourceDatabaseName());
+		assertEquals(373378, replicationTask.getSourceSequenceId());
+		assertEquals(1422566612, replicationTask.getStartedOn().getTime());
+		assertEquals("targetDB", replicationTask.getTargetDatabaseName());
+		assertEquals(1422581543, replicationTask.getUpdatedOn().getTime());
+	}
+
+	private ActiveTask readResourceAsActiveTask(String resourceName) throws IOException {
+		ObjectMapper objectMapper = new ObjectMapper();
+		ActiveTask activeTask;
+		InputStream resourceAsStream = null;
+		try {
+			resourceAsStream = getClass().getResourceAsStream(resourceName);
+			activeTask = objectMapper.readValue(resourceAsStream, StdActiveTask.class);
+		} finally {
+			IOUtils.closeQuietly(resourceAsStream);
+		}
+		return activeTask;
+	}
+
+
+}

--- a/org.ektorp/src/test/resources/org/ektorp/impl/replication_task_sample_with_checkpointinterval.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/replication_task_sample_with_checkpointinterval.json
@@ -1,0 +1,22 @@
+{
+  "pid":"0.992.0>",
+  "checkpoint_interval":5000,
+  "checkpointed_source_seq":95948,
+  "continuous":true,
+  "doc_id":null,
+  "doc_write_failures":0,
+  "docs_read":8,
+  "docs_written":8,
+  "missing_revisions_found":8,
+  "progress":100,
+  "replication_id":"cc86d412959b7c453ab661ce23312db7+continuous",
+  "revisions_checked":777,
+  "source":"sourceDB",
+  "source_seq":373378,
+  "started_on":1422566612,
+  "target":"targetDB",
+  "type":"replication",
+  "updated_on":1422581543
+}
+
+

--- a/org.ektorp/src/test/resources/org/ektorp/impl/replication_task_sample_without_checkpointinterval.json
+++ b/org.ektorp/src/test/resources/org/ektorp/impl/replication_task_sample_without_checkpointinterval.json
@@ -1,0 +1,21 @@
+{
+  "pid":"0.992.0>",
+  "checkpointed_source_seq":95948,
+  "continuous":true,
+  "doc_id":null,
+  "doc_write_failures":0,
+  "docs_read":8,
+  "docs_written":8,
+  "missing_revisions_found":8,
+  "progress":100,
+  "replication_id":"cc86d412959b7c453ab661ce23312db7+continuous",
+  "revisions_checked":777,
+  "source":"sourceDB",
+  "source_seq":373378,
+  "started_on":1422566612,
+  "target":"targetDB",
+  "type":"replication",
+  "updated_on":1422581543
+}
+
+


### PR DESCRIPTION
supporting field 'checkpoint_interval' introduced by CouchDB 1.6 in replication tasks documents