### PR TITLE
disable FindBugs when running on Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,5 +301,14 @@
                 <sonarVersion>2.1</sonarVersion>
             </properties>
         </profile>
+        <profile>
+            <id>jdk16</id>
+            <activation>
+                <jdk>1.6</jdk>
+            </activation>
+            <properties>
+                <findbugs.skip>true</findbugs.skip>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
disable FindBugs when running on Java 6 (since FindBugs 3 requires minimum Java 7 as runtime environment) in order to avoid failing the Travis build on Java 6

Maven will still run FindBugs on Java 7 and higher
