### PR TITLE
reverting interrupted release, to reset back the pom version to SNAPSHOT

### DIFF
--- a/org.ektorp.android/pom.xml
+++ b/org.ektorp.android/pom.xml
@@ -4,12 +4,12 @@
     <artifactId>org.ektorp.android</artifactId>
     <packaging>jar</packaging>
     <name>Ektorp Android</name>
-    <version>1.4.3</version>
+    <version>1.4.3-SNAPSHOT</version>
     <description>Provides Android support to Ektorp</description>
     <parent>
         <groupId>org.ektorp</groupId>
         <artifactId>org.ektorp.parent</artifactId>
-        <version>1.4.3</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/org.ektorp.spring/pom.xml
+++ b/org.ektorp.spring/pom.xml
@@ -4,12 +4,12 @@
 	<artifactId>org.ektorp.spring</artifactId>
 	<packaging>jar</packaging>
 	<name>Ektorp Spring</name>
-	<version>1.4.3</version>
+	<version>1.4.3-SNAPSHOT</version>
 	<description>Provides Spring support to Ektorp</description>
 	<parent>
 		<groupId>org.ektorp</groupId>
 		<artifactId>org.ektorp.parent</artifactId>
-		<version>1.4.3</version>
+		<version>1.4.3-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/org.ektorp/pom.xml
+++ b/org.ektorp/pom.xml
@@ -4,12 +4,12 @@
 	<artifactId>org.ektorp</artifactId>
 	<packaging>jar</packaging>
 	<name>Ektorp</name>
-	<version>1.4.3</version>
+	<version>1.4.3-SNAPSHOT</version>
 	<description>a Java CouchDB persistence library</description>
 	<parent>
 		<artifactId>org.ektorp.parent</artifactId>
 		<groupId>org.ektorp</groupId>
-		<version>1.4.3</version>
+		<version>1.4.3-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>org.ektorp.parent</artifactId>
     <packaging>pom</packaging>
     <name>Ektorp Parent</name>
-    <version>1.4.3</version>
+    <version>1.4.3-SNAPSHOT</version>
     <description>a Java CouchDB persistence library</description>
     <scm>
         <connection>scm:git:git@github.com:helun/Ektorp.git</connection>
@@ -147,7 +147,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>2.5.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
the master branch needs to be fixed, following the interrupted release of Ektorp 1.4.3