### PR TITLE
fix side effect in tests on System Properties

### DIFF
--- a/org.ektorp/src/test/java/org/ektorp/support/CouchDbRepositorySupportTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/support/CouchDbRepositorySupportTest.java
@@ -19,9 +19,18 @@ public class CouchDbRepositorySupportTest {
 
 	@Before
 	public void setUp() throws Exception {
+		System.clearProperty(DesignDocument.UPDATE_ON_DIFF);
+		System.clearProperty(DesignDocument.AUTO_UPDATE_VIEW_ON_CHANGE);
+		
 		db = mock(CouchDbConnector.class, new ThrowsException(new UnsupportedOperationException("This interaction was not expected on this mock")));
         doNothing().when(db).createDatabaseIfNotExists();
 		repo = new CouchDbRepositorySupport<TestDoc>(TestDoc.class, db);
+	}
+
+	@After
+	public void tearDown() {
+		System.clearProperty(DesignDocument.UPDATE_ON_DIFF);
+		System.clearProperty(DesignDocument.AUTO_UPDATE_VIEW_ON_CHANGE);
 	}
 
 	private void setupDesignDoc() throws Exception {

--- a/org.ektorp/src/test/java/org/ektorp/support/DesignDocumentTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/support/DesignDocumentTest.java
@@ -19,6 +19,9 @@ public class DesignDocumentTest {
 
 	@Before
 	public void setup() {
+		System.clearProperty(DesignDocument.UPDATE_ON_DIFF);
+		System.clearProperty(DesignDocument.AUTO_UPDATE_VIEW_ON_CHANGE);
+
 		dd.setRevision("12345");
 		dd.addView("all", new DesignDocument.View("function(doc) { if (doc.Type == 'TestDoc')  emit(null, doc.id) }"));
 		dd.addView("by_lastname", new DesignDocument.View("function(doc) { if (doc.Type == 'TestDoc')  emit(doc.LastName, doc) }"));
@@ -26,6 +29,12 @@ public class DesignDocumentTest {
 		view.setAnonymous("module", "exports.info = {artiest : {name : 'artiest', properties : {naam : {name : 'naam', type : 'string', required : true, searchable : true}}}}");
 		dd.addView("lib", view);
 		dd.setLanguage("javascript");
+	}
+
+	@After
+	public void tearDown() {
+		System.clearProperty(DesignDocument.UPDATE_ON_DIFF);
+		System.clearProperty(DesignDocument.AUTO_UPDATE_VIEW_ON_CHANGE);
 	}
 
 	@Test


### PR DESCRIPTION
fix side effect in tests on System Properties, causing random failed build depending on tests run order

The following test
org.ektorp.support.CouchDbRepositorySupportTest.given_view_already_exists_then_it_should_be_preserved
is often failing because of a side effect of other tests on the system properties.
This is often failing builds on Travis when building Pull Requests.

Tests should make sure that the state of the System Properties are set according to their requirements. Also tests should reset the System Properties so that they do not risk to fail other tests running after them.