### PR TITLE
select the appropriate findbugs version depending of the running JDK major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>${findbugs.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -307,7 +307,25 @@
                 <jdk>1.6</jdk>
             </activation>
             <properties>
-                <findbugs.skip>true</findbugs.skip>
+                <findbugs.plugin.version>2.5.3</findbugs.plugin.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
+            <properties>
+                <findbugs.plugin.version>2.5.3</findbugs.plugin.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <findbugs.plugin.version>3.0.0</findbugs.plugin.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
select the appropriate findbugs version depending of the running JDK major version
do that pom.xml works on java 6, on java 7, and java 8 at the same time in a portable way. No more trouble with that.

I'm sorry for the trouble caused by the introduction of FindBugs in the build process. 
Findbugs 2 cannot run on Java 8. And Findbugs 3 cannot run on Java 6. That was the source of the problem for most of us, including Travis.
Hopefully this commit will fix the issue for all of us, whatever the JDK you have using to build.

This re-enables findbugs on java 6, but using the appropriate version (2.5.3).
Findbugs 2.5.3 will be used when running on Java 7.
Findbugs 3.0.0 will be used when running on Java 8 or later.