### PR TITLE
Adds CouchDbRepositorySupport with full arguments list

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/support/CouchDbRepositorySupport.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/CouchDbRepositorySupport.java
@@ -64,19 +64,34 @@ public class CouchDbRepositorySupport<T> implements GenericRepository<T> {
 		stdDesignDocumentId = NameConventions.designDocName(type);
 	}
 	/**
-	 * Alternative constructor allowing a custom design document name (not linked to the type class name)
+	 * Alternative constructor allowing a custom design document name (not linked to the type class name).
+     *
 	 * @param type
 	 * @param db
 	 * @param designDocName
 	 */
 	protected CouchDbRepositorySupport(Class<T> type, CouchDbConnector db, String designDocName) {
-		Assert.notNull(db, "CouchDbConnector may not be null");
-		Assert.notNull(type);
-		this.db = db;
-		this.type = type;
-		db.createDatabaseIfNotExists();
-		stdDesignDocumentId = NameConventions.designDocName(designDocName);
-	}
+        this(type, db, designDocName, true);
+    }
+
+    /**
+     * Alternative constructor allowing a custom design document name (not linked to the type class name)
+     * @param type repository type
+     * @param db database connector
+     * @param designDocName design document Id
+     * @param createIfNotExists true if db should be created if it doesnt' exist
+     */
+    protected CouchDbRepositorySupport(Class<T> type, CouchDbConnector db, String designDocName, boolean createIfNotExists) {
+        Assert.notNull(db, "CouchDbConnector may not be null");
+        Assert.notNull(type);
+        this.db = db;
+        this.type = type;
+        if (createIfNotExists) {
+            db.createDatabaseIfNotExists();
+        }
+        stdDesignDocumentId = NameConventions.designDocName(designDocName);
+    }
+
 	/**
 	 * @throws UpdateConflictException if there was an update conflict.
 	 */

--- a/org.ektorp/src/test/java/org/ektorp/support/CouchDbRepositorySupportConstructionTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/support/CouchDbRepositorySupportConstructionTest.java
@@ -1,0 +1,49 @@
+package org.ektorp.support;
+
+import org.ektorp.CouchDbConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.internal.stubbing.answers.ThrowsException;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+
+
+public class CouchDbRepositorySupportConstructionTest {
+
+    CouchDbConnector db;
+
+    @Before
+    public void setUp() throws Exception {
+        System.clearProperty(DesignDocument.UPDATE_ON_DIFF);
+        System.clearProperty(DesignDocument.AUTO_UPDATE_VIEW_ON_CHANGE);
+
+        db = mock(CouchDbConnector.class, new ThrowsException(new UnsupportedOperationException("This interaction was not expected on this mock")));
+        doNothing().when(db).createDatabaseIfNotExists();
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(DesignDocument.UPDATE_ON_DIFF);
+        System.clearProperty(DesignDocument.AUTO_UPDATE_VIEW_ON_CHANGE);
+    }
+
+    @Test
+    public void given_design_doc_and_not_createIfExists_constructor_should_not_call_createDatabaseIfNotExists() {
+        final String designDoc = "my_design_doc";
+
+        new CouchDbRepositorySupport<CouchDbRepositorySupportTest.TestDoc>(CouchDbRepositorySupportTest.TestDoc.class, db, designDoc, false);
+
+        verify(db, never()).createDatabaseIfNotExists();
+    }
+
+    @Test
+    public void given_design_doc_andt_createIfExists_constructor_should_call_createDatabaseIfNotExists() {
+        final String designDoc = "my_design_doc";
+
+        new CouchDbRepositorySupport<CouchDbRepositorySupportTest.TestDoc>(CouchDbRepositorySupportTest.TestDoc.class, db, designDoc, true);
+
+        verify(db, times(1)).createDatabaseIfNotExists();
+    }
+}


### PR DESCRIPTION
Adds a new (third) constructor to CouchDbRepositorySupport taking a
design document Id and createIfNotExists boolean.

A separate CouchDbRepositorySupportConstructorTest class is added to
the support package as well, verifying createIfNotExists behavior.

Fixes #228 