### PR TITLE
Cross-Platform New Line for SimpleViewGenerator

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/support/SimpleViewGenerator.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/SimpleViewGenerator.java
@@ -26,6 +26,7 @@ public class SimpleViewGenerator {
 	private final static String ITERABLE_PROPERTY_BODY = "for (var i in doc.%s) {emit(doc.%s[i], doc._id);}";
 	private final static String REFERING_CHILDREN_AS_SET_W_ORDER_BY = "function(doc) { if(%s) { emit([doc.%s, '%s', doc.%s], null); } }";
 	private final static String REFERING_CHILDREN_AS_SET = "function(doc) { if(%s) { emit([doc.%s, '%s'], null); } }";
+	private final static String LINE_ENDING = String.format("%n");
 
 	private SoftReference<ObjectMapper> mapperRef;
 
@@ -275,7 +276,7 @@ public class SimpleViewGenerator {
 		try {
 			String json = loadResourceFromClasspath(repositoryClass,
 					input.file());
-			return mapper().readValue(json.replaceAll("\n", ""),
+			return mapper().readValue(json.replaceAll(LINE_ENDING, ""),
 					DesignDocument.View.class);
 		} catch (Exception e) {
 			throw Exceptions.propagate(e);


### PR DESCRIPTION
Running a maven build on non-*nix machines fails `SimpleViewGeneratorTest`
because of line endings. This functionality already works on Windows,
but tests fail because of a reference to `String#replaceAll("\n", "")`.
This changes defines the cross-platform `String.format("%n")` as a
constant, and references it in the `replaceAll` call as per
http://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html#syntax