### PR TITLE
Fix Serialization Regression from Upgrade to Jackson 2

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
@@ -47,7 +47,7 @@ public class StdObjectMapperFactory implements ObjectMapperFactory {
 
 	private void applyDefaultConfiguration(ObjectMapper om) {
 		om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, this.writeDatesAsTimestamps);
-		om.getSerializationConfig().withSerializationInclusion(JsonInclude.Include.NON_NULL);
+		om.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 	}
 
 }

--- a/org.ektorp/src/test/java/org/ektorp/impl/StdObjectMapperFactoryTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/impl/StdObjectMapperFactoryTest.java
@@ -1,0 +1,54 @@
+package org.ektorp.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StdObjectMapperFactoryTest {
+
+	private StdObjectMapperFactory factory;
+
+	@Before
+	public void setUp() {
+		factory = new StdObjectMapperFactory();
+	}
+
+	@Test
+	public void shouldSerializeBeanPropertiesByDefault() throws JsonProcessingException {
+		ObjectMapper objectMapper = factory.createObjectMapper();
+
+		String actual = objectMapper.writeValueAsString(new Pair("couch", "db"));
+
+		assertEquals("{\"name\":\"couch\",\"value\":\"db\"}", actual);
+	}
+
+	@Test
+	public void shouldNotSerializeNullBeanPropertiesByDefault() throws JsonProcessingException {
+		ObjectMapper objectMapper = factory.createObjectMapper();
+
+		String actual = objectMapper.writeValueAsString(new Pair("couch", null));
+
+		assertEquals("{\"name\":\"couch\"}", actual);
+	}
+
+	public static class Pair {
+		private String name;
+		private String value;
+
+		public Pair(String name, String value) {
+			this.name = name;
+			this.value = value;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+}


### PR DESCRIPTION
After upgrading my app from Ektorp 1.3 to Ektorp 1.4, I started having an
error with sending a document that included {"_rev":null}. I dug into the framework
a bit and think I found the cause.

The `StdObjectMapperFactory` is now calling `setSerializationInclusion`
directly on the `ObjectMapper` to ignore null fields in the default
configuration.

In Jackson 1, it was OK to modify the `SerializationConfig` of an
`ObjectMapper`. In Jackson 2, the `SerializationConfig` is immutable
and calling the `with...` methods produces a new copy of the object that
can no longer be assigned to an `ObjectMapper`.

https://fasterxml.github.io/jackson-databind/javadoc/2.3.0/com/fasterxml/jackson/databind/SerializationConfig.html
