### PR TITLE
Programmaticaly choose updateOnDiff for DesignDocument#mergeWith

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/support/DesignDocument.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/DesignDocument.java
@@ -184,14 +184,35 @@ public class DesignDocument extends OpenCouchDbDocument {
         filters().remove(name);
     }
 
-    public boolean mergeWith(DesignDocument dd) {
-        boolean updateOnDiff = updateOnDiff();
+    /**
+     * Merge this design document with the specified document, the result being
+     * stored in this design document.
+     *
+     * @param dd
+     *            the design document to merge with
+     * @param updateOnDiff
+     *            true to overwrite existing views/functions in this document
+     *            with the views/functions in the specified document; false will
+     *            only add new views/functions.
+     * @return true if there was any modification to this document, false otherwise.
+     */
+    public boolean mergeWith(DesignDocument dd, boolean updateOnDiff) {
         boolean changed = mergeViews(dd.views(), updateOnDiff);
         changed = mergeFunctions(lists(), dd.lists(), updateOnDiff) || changed;
         changed = mergeFunctions(shows(), dd.shows(), updateOnDiff) || changed;
         changed = mergeFunctions(filters(), dd.filters(), updateOnDiff) || changed;
         changed = mergeFunctions(updates(), dd.updates(), updateOnDiff) || changed;
         return changed;
+    }
+
+    /**
+     * This method will check for the two system properties boolean
+     * {@link #AUTO_UPDATE_VIEW_ON_CHANGE} and {@link #UPDATE_ON_DIFF}, then call
+     * {@link #mergeWith(DesignDocument, boolean)}. The default value is false for both.
+     *
+     */
+    public boolean mergeWith(DesignDocument dd) {
+        return mergeWith(dd, updateOnDiff());
     }
 
     private boolean mergeFunctions(Map<String, String> existing, Map<String, String> mergeFunctions,


### PR DESCRIPTION
Add an overloaded version of `mergeWith` that accepts a second parameter deciding whether or not to update the DesignDocument when it has changed from its original version. Default behavior is untouched and still rely on System properties to decided whether or not to update `DesignDocument` when it has changed from its original version.

Tell me if you would prefer the patch without additional function comments. Also, I retain original ownership of the patch since I simply removed some stuff and re-worded the commit message.

Supersedes PR #99