### PR TITLE
Field "total_rows" is handled as "long" instead of "int" 

### DIFF
--- a/org.ektorp.android/pom.xml
+++ b/org.ektorp.android/pom.xml
@@ -4,12 +4,12 @@
     <artifactId>org.ektorp.android</artifactId>
     <packaging>jar</packaging>
     <name>Ektorp Android</name>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3.1</version>
     <description>Provides Android support to Ektorp</description>
     <parent>
         <groupId>org.ektorp</groupId>
         <artifactId>org.ektorp.parent</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3.1</version>
     </parent>
 
     <dependencies>

--- a/org.ektorp.spring/pom.xml
+++ b/org.ektorp.spring/pom.xml
@@ -4,12 +4,12 @@
 	<artifactId>org.ektorp.spring</artifactId>
 	<packaging>jar</packaging>
 	<name>Ektorp Spring</name>
-	<version>1.4.3-SNAPSHOT</version>
+	<version>1.4.3.1</version>
 	<description>Provides Spring support to Ektorp</description>
 	<parent>
 		<groupId>org.ektorp</groupId>
 		<artifactId>org.ektorp.parent</artifactId>
-		<version>1.4.3-SNAPSHOT</version>
+		<version>1.4.3.1</version>
 	</parent>
 
 	<dependencies>

--- a/org.ektorp/pom.xml
+++ b/org.ektorp/pom.xml
@@ -4,12 +4,12 @@
 	<artifactId>org.ektorp</artifactId>
 	<packaging>jar</packaging>
 	<name>Ektorp</name>
-	<version>1.4.3-SNAPSHOT</version>
+	<version>1.4.3.1</version>
 	<description>a Java CouchDB persistence library</description>
 	<parent>
 		<artifactId>org.ektorp.parent</artifactId>
 		<groupId>org.ektorp</groupId>
-		<version>1.4.3-SNAPSHOT</version>
+		<version>1.4.3.1</version>
 	</parent>
 
 	<dependencies>

--- a/org.ektorp/src/main/java/org/ektorp/Page.java
+++ b/org.ektorp/src/main/java/org/ektorp/Page.java
@@ -5,14 +5,14 @@ import java.util.List;
 
 public class Page<T> implements Iterable<T> {
 
-	private final int totalSize;
+	private final long totalSize;
 	private final int pageSize;
 	private final PageRequest previousPageRequest;
 	private final PageRequest nextPageRequest;
 	
 	private final List<T> rows;
 	
-	public Page(List<T> rows, int totalSize, int pageSize, PageRequest previousPageRequest,  PageRequest nextPageRequest) {
+	public Page(List<T> rows, long  totalSize, int pageSize, PageRequest previousPageRequest,  PageRequest nextPageRequest) {
 		this.rows = rows;
 		this.totalSize = totalSize;
 		this.pageSize = pageSize;
@@ -49,7 +49,7 @@ public class Page<T> implements Iterable<T> {
 	/**
 	 * @return the total number of items across all pages
 	 */
-	public int getTotalSize() {
+	public long getTotalSize() {
 		return totalSize;
 	}
 	/**

--- a/org.ektorp/src/main/java/org/ektorp/ViewResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewResult.java
@@ -22,7 +22,7 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 	private static final String TOTAL_ROWS_FIELD_NAME = "total_rows";
 	private static final String UPDATE_SEQ = "update_seq";
 	private static final long serialVersionUID = 4750290767933801714L;
-	private int totalRows = -1;
+	private long totalRows = -1;
 	private int offset = -1;
 	private String updateSeq;
 
@@ -33,7 +33,7 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
         Assert.notNull(resultNode, "resultNode may not be null");
 		Assert.isTrue(resultNode.findPath("rows").isArray(), "result must contain 'rows' field of array type");
 		if (resultNode.get(TOTAL_ROWS_FIELD_NAME) != null) {
-			totalRows = resultNode.get(TOTAL_ROWS_FIELD_NAME).intValue();
+			totalRows = resultNode.get(TOTAL_ROWS_FIELD_NAME).longValue();
 		}
 		if (resultNode.get(OFFSET_FIELD_NAME) != null) {
 			offset = resultNode.get(OFFSET_FIELD_NAME).intValue();
@@ -76,7 +76,7 @@ public class ViewResult implements Iterable<ViewResult.Row>, Serializable {
 	 *
 	 * @return -1 if result did not contain a total_rows field
 	 */
-	public int getTotalRows() {
+	public long getTotalRows() {
 		return totalRows;
 	}
 

--- a/org.ektorp/src/main/java/org/ektorp/impl/QueryResultParser.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/QueryResultParser.java
@@ -32,7 +32,7 @@ public class QueryResultParser<T> {
     private static final String OFFSET_FIELD_NAME = "offset";
     private static final String UPDATE_SEQUENCE_NAME = "update_seq";
 
-    private int totalRows = -1;
+    private long totalRows = -1;
     private long offset = -1;
     private List<T> rows;
     private Long updateSequence;
@@ -74,7 +74,7 @@ public class QueryResultParser<T> {
             if (OFFSET_FIELD_NAME.equals(currentName)) {
                 offset = jp.getLongValue();
             } else if (TOTAL_ROWS_FIELD_NAME.equals(currentName)) {
-                totalRows = jp.getIntValue();
+                totalRows = jp.getLongValue();
             } else if (ROWS_FIELD_NAME.equals(currentName)) {
                 rows = new ArrayList<T>();
                 parseRows(jp);
@@ -165,7 +165,7 @@ public class QueryResultParser<T> {
         return ignoreNotFound && NOT_FOUND_ERROR.equals(error);
     }
 
-    public int getTotalRows() {
+    public long getTotalRows() {
         return totalRows;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>org.ektorp.parent</artifactId>
     <packaging>pom</packaging>
     <name>Ektorp Parent</name>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3.1</version>
     <description>a Java CouchDB persistence library</description>
     <scm>
         <connection>scm:git:git@github.com:helun/Ektorp.git</connection>


### PR DESCRIPTION
When the database has a large number of documents (around 2500 million documents), the parsing of a query response may crash with an "integer out of range" kind of error, because the content of "total_rows" exceeds the max value for an integer variable.