### PR TITLE
Use keys when creating the query if needed

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/PageRequest.java
+++ b/org.ektorp/src/main/java/org/ektorp/PageRequest.java
@@ -31,9 +31,15 @@ public class PageRequest {
 	public static ViewQuery applyPagingParameters(ViewQuery q, PageRequest pr) {
 		ViewQuery pagedQuery = q.clone();
 		if (pr.page > 0) {
-			if (pr.getStartKey() != null) {
-				pagedQuery.startKey(pr.getStartKey());
-			}
+            if(q.getKeysValues().size() > 0)
+            {
+                pagedQuery.keys(q.getKeysValues());
+            }
+            else {
+                if (pr.getStartKey() != null) {
+                    pagedQuery.startKey(pr.getStartKey());
+                }
+            }
 			if (pr.getStartKeyDocId() != null) {
 				pagedQuery.startDocId(pr.getStartKeyDocId());
 			}
@@ -142,10 +148,7 @@ public class PageRequest {
 		return nextKey != null ? nextKey.docId : null;
 	}
 	/**
-	 * 
-	 * @param startKey
-	 * @param startDocId
-	 * @return
+	 * @return PageRequest
 	 */
 	public PageRequest getPreviousPageRequest() {
 		return new Builder(this)


### PR DESCRIPTION
This fixes an issue where the second page of results would be broken
because startkey was being set rather than using the keys array for the
query. Resulted in the below error from Couch.

Response Body:
{
"error" : "query_parse_error",
"reason" : "keys is incompatible with key, start_key and end_key"
}