### PR TITLE
Ignore empty lines when parsing view results.

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/StreamingViewResult.java
+++ b/org.ektorp/src/main/java/org/ektorp/StreamingViewResult.java
@@ -110,6 +110,9 @@ public class StreamingViewResult implements Serializable, Iterable<Row>, Closeab
 			    JsonNode node;
 			    do {
     				String doc = reader.readLine();
+    				while (doc != null && doc.isEmpty()) {
+    					doc = reader.readLine();
+    				}
     				if (doc == null || doc.equals("]}")) {
     					reader.close();
 					closed = true;


### PR DESCRIPTION
When a view produces no rows, my version of CouchDB (1.6.1) returns an empty line in the rows array:

```
$ http --pretty none http://.../_view/updates
HTTP/1.1 200 OK
Server: CouchDB/1.6.1 (Erlang OTP/17)
(...)

{"total_rows":0,"offset":0,"rows":[

]}
```

Trying to iterate over the rows using StreamingViewResult.iterator() fails:

```
org.ektorp.DbAccessException: com.fasterxml.jackson.databind.JsonMappingException: No content to map due to end-of-input at [Source: ; line: 1, column: 0]
        at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:270)
        at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:3838)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3783)
        at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:2381)
        at org.ektorp.StreamingViewResult$StreamingViewResultIterator.hasNext(StreamingViewResult.java:121)
        at java.lang.Iterable.forEach(Iterable.java:74)
        (...)
```

The attached patch skips the empty lines.