### PR TITLE
Provide a way to use Jackson 2.9.0

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
@@ -1,6 +1,5 @@
 package org.ektorp;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -14,6 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.ektorp.http.URI;
+import org.ektorp.impl.ObjectMapperFactory;
+import org.ektorp.impl.CachingObjectMapperFactory;
 import org.ektorp.impl.StdObjectMapperFactory;
 import org.ektorp.util.Assert;
 import org.ektorp.util.Exceptions;
@@ -84,13 +85,19 @@ public class ViewQuery {
 	}
 	
 
-	private final static ObjectMapper DEFAULT_MAPPER = new StdObjectMapperFactory().createObjectMapper();
+	private static ObjectMapperFactory DEFAULT_OBJECT_MAPPER_FACTORY = new CachingObjectMapperFactory(new StdObjectMapperFactory());
+	
+	public static void setDefaultObjectMapperFactory(ObjectMapperFactory objectMapperFactory) {
+		DEFAULT_OBJECT_MAPPER_FACTORY = objectMapperFactory;
+	}
+	
+	
 	private final static String ALL_DOCS_VIEW_NAME = "_all_docs";
 	private final static int NOT_SET = -1;
 
 	private final Map<String, String> queryParams = new TreeMap<String, String>();
 
-	private ObjectMapper mapper;
+	private final ObjectMapper mapper;
 
 	private String dbPath;
 	private String designDocId;
@@ -119,7 +126,7 @@ public class ViewQuery {
 	private String listName;
 
 	public ViewQuery() {
-		mapper = DEFAULT_MAPPER;
+		this(DEFAULT_OBJECT_MAPPER_FACTORY.createObjectMapper());
 	}
 	/**
 	 * Bring your own ObjectMapper.
@@ -726,8 +733,7 @@ public class ViewQuery {
 
     @edu.umd.cs.findbugs.annotations.SuppressWarnings({"SA_FIELD_SELF_ASSIGNMENT", "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE"})
 	public ViewQuery clone() {
-		ViewQuery copy = new ViewQuery();
-		copy.mapper = mapper;
+		ViewQuery copy = new ViewQuery(mapper);
 		copy.cacheOk = cacheOk;
 		copy.dbPath = dbPath;
 		copy.descending = descending;
@@ -964,7 +970,7 @@ public class ViewQuery {
 		}
 
 		public String toJson() {
-			return toJson(DEFAULT_MAPPER);
+			return toJson(DEFAULT_OBJECT_MAPPER_FACTORY.createObjectMapper());
 		}
 
 		public String toJson(ObjectMapper mapper) {

--- a/org.ektorp/src/main/java/org/ektorp/impl/CachingObjectMapperFactory.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/CachingObjectMapperFactory.java
@@ -1,0 +1,32 @@
+package org.ektorp.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ektorp.CouchDbConnector;
+
+public class CachingObjectMapperFactory implements ObjectMapperFactory {
+
+	private final ObjectMapperFactory delegate;
+
+	private ObjectMapper objectMapperInstance;
+
+	public CachingObjectMapperFactory(ObjectMapperFactory delegate) {
+		super();
+		this.delegate = delegate;
+	}
+
+	@Override
+	public ObjectMapper createObjectMapper() {
+		ObjectMapper result = objectMapperInstance;
+		if (result == null) {
+			result = delegate.createObjectMapper();
+			objectMapperInstance = result;
+		}
+		return result;
+	}
+
+	@Override
+	public ObjectMapper createObjectMapper(CouchDbConnector connector) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
@@ -47,7 +47,12 @@ public class StdObjectMapperFactory implements ObjectMapperFactory {
 
 	private void applyDefaultConfiguration(ObjectMapper om) {
 		om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, this.writeDatesAsTimestamps);
+
+		// method was removed in jackson 2.9.0
 		om.getSerializationConfig().withSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+		// method introduced in jackson 2.7.0
+		// om.getSerializationConfig().withPropertyInclusion(JsonInclude.Value.empty().withValueInclusion(JsonInclude.Include.NON_NULL));
 	}
 
 }

--- a/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/StdObjectMapperFactory.java
@@ -45,7 +45,10 @@ public class StdObjectMapperFactory implements ObjectMapperFactory {
 		this.writeDatesAsTimestamps = b;
 	}
 
-	private void applyDefaultConfiguration(ObjectMapper om) {
+	/**
+	 * This protected method can be overridden in order to change the configuration.
+	 */
+	protected void applyDefaultConfiguration(ObjectMapper om) {
 		om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, this.writeDatesAsTimestamps);
 
 		// method was removed in jackson 2.9.0

--- a/org.ektorp/src/main/java/org/ektorp/impl/jackson/EktorpBeanDeserializerModifier.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/jackson/EktorpBeanDeserializerModifier.java
@@ -1,34 +1,6 @@
 package org.ektorp.impl.jackson;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import org.ektorp.CouchDbConnector;
-import org.ektorp.docref.DocumentReferences;
-import org.ektorp.impl.docref.BackReferencedBeanDeserializer;
-import org.ektorp.impl.docref.ConstructibleAnnotatedCollection;
-import org.ektorp.util.Predicate;
-import org.ektorp.util.ReflectionUtils;
-
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.BeanDeserializer;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
@@ -40,6 +12,18 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.databind.util.SimpleBeanPropertyDefinition;
+import org.ektorp.CouchDbConnector;
+import org.ektorp.docref.DocumentReferences;
+import org.ektorp.impl.docref.BackReferencedBeanDeserializer;
+import org.ektorp.impl.docref.ConstructibleAnnotatedCollection;
+import org.ektorp.util.Predicate;
+import org.ektorp.util.ReflectionUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
 
 public class EktorpBeanDeserializerModifier extends BeanDeserializerModifier {
 
@@ -126,7 +110,10 @@ public class EktorpBeanDeserializerModifier extends BeanDeserializerModifier {
 		// need to ensure method is callable (for non-public)
 		if (config
 				.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) {
-			setter.fixAccess();
+			Method member = setter.getAnnotated();
+			if (!Modifier.isPublic(member.getModifiers()) || !Modifier.isPublic(member.getDeclaringClass().getModifiers())) {
+				member.setAccessible(true);
+			}
 		}
 
 		/*

--- a/org.ektorp/src/main/java/org/ektorp/support/CouchDbRepositorySupport.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/CouchDbRepositorySupport.java
@@ -333,7 +333,13 @@ public class CouchDbRepositorySupport<T> implements GenericRepository<T> {
 	protected void debugDesignDoc(DesignDocument generated) {
 		ObjectMapper om = new ObjectMapper();
 		om.configure(SerializationFeature.INDENT_OUTPUT, true);
+
+		// method was removed in jackson 2.9.0
 		om.getSerializationConfig().withSerializationInclusion(JsonInclude.Include.NON_NULL);
+		
+		// method introduced in jackson 2.7.0
+		// om.getSerializationConfig().withPropertyInclusion(JsonInclude.Value.empty().withValueInclusion(JsonInclude.Include.NON_NULL));
+		
 		try {
 			String json = om.writeValueAsString(generated);
 			log.debug("DesignDocument source:\n" + json);


### PR DESCRIPTION
Jackson 2.9.0 removed at least some of methods that Ektorp used for a while.

So in order to be able to use Jackson 2.9.0, we need to be able to override the Ektorp code that use those methods that were removed.

This PR provides ways for Ektorp users to override the code in order to work with Jackson 2.9.0.