### PR TITLE
upgrade Jackson lib to latest version that pass tests : version 2.6.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <mockito.version>1.8.5</mockito.version>
         <junit.version>4.8.2</junit.version>
         <joda.time.version>2.3</joda.time.version>
-        <jackson.version>2.3.3</jackson.version>
+        <jackson.version>2.6.7</jackson.version>
         <spring.version>3.1.1.RELEASE</spring.version>
         <commons.io.version>2.0.1</commons.io.version>
         <httpclient.version>4.3</httpclient.version>


### PR DESCRIPTION
Bump to the latest version that does not break any test : 2.6.9

Tests on feature ```@DocumentReferences``` are not passing with Jackson version 2.7.0 and later.

Users that do not make use of feature ```@DocumentReferences``` should generally be safe to use 2.7.0 or later. (until version 2.9.0 that introduced an API change, see #269)