### PR TITLE
Allow empty inline attachments

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
+++ b/org.ektorp/src/main/java/org/ektorp/ViewQuery.java
@@ -112,6 +112,7 @@ public class ViewQuery {
 	private boolean inclusiveEnd = true;
 	private boolean ignoreNotFound = false;
 	private boolean updateSeq = false;
+	private boolean conflicts = false;
 
 	private boolean cacheOk = false;
 
@@ -190,6 +191,10 @@ public class ViewQuery {
     public boolean isUpdateSeq() {
         return updateSeq;
     }
+
+	public boolean isConflicts() {
+		return conflicts;
+	}
 
     public ViewQuery dbPath(String s) {
 		reset();
@@ -608,6 +613,17 @@ public class ViewQuery {
 		return this;
 	}
 
+	/**
+	 * The conflicts option will include the conflicting revisions for each document.
+	 * @param b the conflicts flag
+	 * @return the view query for chained calls
+	 */
+	public ViewQuery conflicts(boolean b) {
+		reset();
+		conflicts = b;
+		return this;
+	}
+
 	public ViewQuery queryParam(String name, String value) {
 		queryParams.put(name, value);
 		return this;
@@ -721,6 +737,11 @@ public class ViewQuery {
 		if(updateSeq) {
 			query.param("update_seq", "true");
 		}
+
+		if (conflicts) {
+			query.param("conflicts", "true");
+		}
+
 		return query;
 	}
 
@@ -752,6 +773,7 @@ public class ViewQuery {
 		copy.startDocId = startDocId;
 		startKey.copyTo(copy.startKey);
 		copy.updateSeq = updateSeq;
+		copy.conflicts = conflicts;
 		copy.viewName = viewName;
 		return copy;
 	}
@@ -813,6 +835,7 @@ public class ViewQuery {
 		result = prime * result + (includeDocs ? 1231 : 1237);
 		result = prime * result + (inclusiveEnd ? 1231 : 1237);
 		result = prime * result + (updateSeq ? 1231 : 1237);
+		result = prime * result + (conflicts ? 1231 : 1237);
 		result = prime * result + ((key == null) ? 0 : key.hashCode());
 		result = prime * result + limit;
 		result = prime * result
@@ -877,6 +900,8 @@ public class ViewQuery {
 		if (inclusiveEnd != other.inclusiveEnd)
 			return false;
 		if (updateSeq != other.updateSeq)
+			return false;
+		if (conflicts != other.conflicts)
 			return false;
 		if (key == null) {
 			if (other.key != null)

--- a/org.ektorp/src/main/java/org/ektorp/support/CouchDbDocument.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/CouchDbDocument.java
@@ -117,7 +117,6 @@ public class CouchDbDocument implements Serializable {
 
 	protected void addInlineAttachment(Attachment a) {
 		Assert.notNull(a, "attachment may not be null");
-		Assert.hasText(a.getDataBase64(), "attachment must have data base64-encoded");
 		if (attachments == null) {
 			attachments = new HashMap<String, Attachment>();
 		}

--- a/org.ektorp/src/test/java/org/ektorp/ViewQueryTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/ViewQueryTest.java
@@ -219,7 +219,15 @@ public class ViewQueryTest {
                         .buildQuery();
                 assertTrue(contains(url, "?update_seq=true"));
         }
-	
+
+	@Test
+	public void conflicts_parameter_added() {
+		String url = query
+				.conflicts(true)
+				.buildQuery();
+		assertTrue(contains(url, "?conflicts=true"));
+	}
+
 	@Test
 	public void stale_ok_parameter_added() {
 		String url = query


### PR DESCRIPTION
The following assertion in CouchDbDocument.addInlineAttachment() prevents me from adding empty inline attachments (attachments with a size of zero bytes) to my documents:

`Assert.hasText(a.getDataBase64(), "attachment must have data base64-encoded");`

Maybe we could remove that assertion? Or at least include a comment with the rationale for the assertion in the code?