### PR TITLE
Allow empty inline attachments

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/support/CouchDbDocument.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/CouchDbDocument.java
@@ -117,7 +117,6 @@ public class CouchDbDocument implements Serializable {
 
 	protected void addInlineAttachment(Attachment a) {
 		Assert.notNull(a, "attachment may not be null");
-		Assert.hasText(a.getDataBase64(), "attachment must have data base64-encoded");
 		if (attachments == null) {
 			attachments = new HashMap<String, Attachment>();
 		}


### PR DESCRIPTION
The following assertion in CouchDbDocument.addInlineAttachment() prevents me from adding empty inline attachments (attachments with a size of zero bytes) to my documents:

`Assert.hasText(a.getDataBase64(), "attachment must have data base64-encoded");`

Maybe we could remove that assertion? Or at least include a comment with the rationale for the assertion in the code?