### PR TITLE
Support for View files using DOS End Of Line

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/support/SimpleViewGenerator.java
+++ b/org.ektorp/src/main/java/org/ektorp/support/SimpleViewGenerator.java
@@ -26,7 +26,9 @@ public class SimpleViewGenerator {
 	private final static String ITERABLE_PROPERTY_BODY = "for (var i in doc.%s) {emit(doc.%s[i], doc._id);}";
 	private final static String REFERING_CHILDREN_AS_SET_W_ORDER_BY = "function(doc) { if(%s) { emit([doc.%s, '%s', doc.%s], null); } }";
 	private final static String REFERING_CHILDREN_AS_SET = "function(doc) { if(%s) { emit([doc.%s, '%s'], null); } }";
-	private final static String LINE_ENDING = String.format("%n");
+	
+	private final static String LINE_ENDING_UNIX = "\n";
+	private final static String LINE_ENDING_DOS = "\r\n";
 
 	private SoftReference<ObjectMapper> mapperRef;
 
@@ -276,11 +278,15 @@ public class SimpleViewGenerator {
 		try {
 			String json = loadResourceFromClasspath(repositoryClass,
 					input.file());
-			return mapper().readValue(json.replaceAll(LINE_ENDING, ""),
-					DesignDocument.View.class);
+			return loadViewFromString(mapper(), json);
 		} catch (Exception e) {
 			throw Exceptions.propagate(e);
 		}
+	}
+
+	public static DesignDocument.View loadViewFromString(ObjectMapper objectMapper, String json) throws IOException {
+		return objectMapper.readValue(json.replaceAll(LINE_ENDING_DOS, "").replaceAll(LINE_ENDING_UNIX, ""),
+				DesignDocument.View.class);
 	}
 
 	private boolean isIterable(Class<?> type) {

--- a/org.ektorp/src/test/java/org/ektorp/support/SimpleViewGeneratorTest.java
+++ b/org.ektorp/src/test/java/org/ektorp/support/SimpleViewGeneratorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -165,6 +166,20 @@ public class SimpleViewGeneratorTest {
 		DiscriminatingRepo repo = new DiscriminatingRepo(db);
 		Map<String, DesignDocument.View> result = gen.generateViews(repo);
 		assertEquals(expectedDocrefsFunctionWhereChildHasDiscriminator, result.get("ektorp_docrefs_children").getMap());
+	}
+
+	@Test
+	public void given_json_view_file_with_unix_line_endings_then_should_parse_successfully() throws IOException {
+		SimpleViewGenerator generator = new SimpleViewGenerator();
+		DesignDocument.View view = generator.loadViewFromString(new ObjectMapper(), " {\"map\":\"function(doc) {\n  emit(doc._id, doc);\n  }\n\"}");
+		assertEquals("function(doc) {  emit(doc._id, doc);  }", view.getMap());
+	}
+
+	@Test
+	public void given_json_view_file_with_dos_line_endings_then_should_parse_successfully() throws IOException {
+		SimpleViewGenerator generator = new SimpleViewGenerator();
+		DesignDocument.View view = generator.loadViewFromString(new ObjectMapper(), " {\"map\":\"function(doc) {\r\n  emit(doc._id, doc);\r\n  }\r\n\"}");
+		assertEquals("function(doc) {  emit(doc._id, doc);  }", view.getMap());
 	}
 	
 // ******************************* S U P P O R T   T Y P E S   B E L O W ********************************* //


### PR DESCRIPTION
when View files are using DOS EOL but the JVM is running on Linux, the DOS EOL should be removed as well

this PR is an alternative to #271
