### PR TITLE
Update to Jackson 2.9.x

### DIFF
--- a/org.ektorp/src/main/java/org/ektorp/impl/jackson/EktorpAnnotationIntrospector.java
+++ b/org.ektorp/src/main/java/org/ektorp/impl/jackson/EktorpAnnotationIntrospector.java
@@ -14,6 +14,7 @@ import org.ektorp.impl.NameConventions;
 import org.ektorp.util.Predicate;
 import org.ektorp.util.ReflectionUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
@@ -46,6 +47,7 @@ public class EktorpAnnotationIntrospector extends NopAnnotationIntrospector {
 		return names.contains(m.getName());
 	}
 
+	// deprecated as of Jackson 2.6 and not called at all by 2.7
 	@Override
 	public String[] findPropertiesToIgnore(Annotated ac) {
 		if(ac instanceof AnnotatedClass){
@@ -53,8 +55,29 @@ public class EktorpAnnotationIntrospector extends NopAnnotationIntrospector {
 		}
 		return super.findPropertiesToIgnore(ac);
 	}
-	
-    public String[] findPropertiesToIgnore(AnnotatedClass ac) {
+
+	// deprecated as of Jackson 2.8 and not called at all by 2.9
+  @Override
+  public String[] findPropertiesToIgnore(Annotated ac, boolean forSerialization) {
+	  if(ac instanceof AnnotatedClass){
+		  return findPropertiesToIgnore((AnnotatedClass) ac);
+	  }
+	  return super.findPropertiesToIgnore(ac, forSerialization);
+  }
+
+  @Override // since Jackson 2.9
+	public JsonIgnoreProperties.Value findPropertyIgnorals(Annotated ac)
+	{
+		if(ac instanceof AnnotatedClass){
+			String[] ignoredFields = findPropertiesToIgnore((AnnotatedClass) ac);
+			if (ignoredFields != null) {
+				return JsonIgnoreProperties.Value.forIgnoredProperties(ignoredFields);
+			}
+		}
+		return super.findPropertyIgnorals(ac);
+	}
+
+	public String[] findPropertiesToIgnore(AnnotatedClass ac) {
     	List<String> ignoreFields = null;
     	for (AnnotatedField f : ac.fields()) {
     		if (isIgnorableField(f)) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <mockito.version>1.8.5</mockito.version>
         <junit.version>4.8.2</junit.version>
         <joda.time.version>2.3</joda.time.version>
-        <jackson.version>2.6.7</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <spring.version>3.1.1.RELEASE</spring.version>
         <commons.io.version>2.0.1</commons.io.version>
         <httpclient.version>4.3</httpclient.version>


### PR DESCRIPTION
We need to use ektorp in an environment that already has dependencies on much newer versions of the Jackson library. The only changes needed are in the EktorpAnnotationIntrospector class. 